### PR TITLE
Use accumulators to count number of rows being written in pyspark

### DIFF
--- a/pkg/api/context/context.go
+++ b/pkg/api/context/context.go
@@ -29,7 +29,7 @@ type Context struct {
 	CortexConfig        *CortexConfig       `json:"cortex_config"`
 	DatasetVersion      string              `json:"dataset_version"`
 	Root                string              `json:"root"`
-	RawDatasetKey       string              `json:"raw_dataset_key"`
+	RawDataset          RawDataset          `json:"raw_dataset"`
 	StatusPrefix        string              `json:"status_prefix"`
 	App                 *App                `json:"app"`
 	Environment         *Environment        `json:"environment"`
@@ -41,6 +41,11 @@ type Context struct {
 	Constants           Constants           `json:"constants"`
 	Aggregators         Aggregators         `json:"aggregators"`
 	Transformers        Transformers        `json:"transformers"`
+}
+
+type RawDataset struct {
+	Key         string `json:"key"`
+	MetadataKey string `json:"metadata_key"`
 }
 
 type Resource interface {

--- a/pkg/operator/context/context.go
+++ b/pkg/operator/context/context.go
@@ -70,7 +70,10 @@ func New(
 		ctx.DatasetVersion,
 		ctx.Environment.ID,
 	)
-	ctx.RawDatasetKey = filepath.Join(ctx.Root, consts.RawDataDir, "raw.parquet")
+	ctx.RawDataset = context.RawDataset{
+		Key:         filepath.Join(ctx.Root, consts.RawDataDir, "raw.parquet"),
+		MetadataKey: filepath.Join(ctx.Root, consts.RawDataDir, "metadata.json"),
+	}
 
 	ctx.StatusPrefix = StatusPrefix(ctx.App.Name)
 
@@ -146,7 +149,7 @@ func calculateID(ctx *context.Context) string {
 	ids = append(ids, ctx.CortexConfig.ID)
 	ids = append(ids, ctx.DatasetVersion)
 	ids = append(ids, ctx.Root)
-	ids = append(ids, ctx.RawDatasetKey)
+	ids = append(ids, ctx.RawDataset.Key)
 	ids = append(ids, ctx.StatusPrefix)
 	ids = append(ids, ctx.App.ID)
 	ids = append(ids, ctx.Environment.ID)

--- a/pkg/operator/workloads/data_job.go
+++ b/pkg/operator/workloads/data_job.go
@@ -60,7 +60,7 @@ func dataJobSpec(
 func dataWorkloadSpecs(ctx *context.Context) ([]*WorkloadSpec, error) {
 	workloadID := generateWorkloadID()
 
-	rawFileExists, err := aws.IsS3File(filepath.Join(ctx.RawDatasetKey, "_SUCCESS"))
+	rawFileExists, err := aws.IsS3File(filepath.Join(ctx.RawDataset.Key, "_SUCCESS"))
 	if err != nil {
 		return nil, errors.Wrap(err, ctx.App.Name, "raw dataset")
 	}

--- a/pkg/workloads/lib/context.py
+++ b/pkg/workloads/lib/context.py
@@ -62,7 +62,7 @@ class Context:
         self.cortex_config = self.ctx["cortex_config"]
         self.dataset_version = self.ctx["dataset_version"]
         self.root = self.ctx["root"]
-        self.raw_dataset_key = self.ctx["raw_dataset_key"]
+        self.raw_dataset = self.ctx["raw_dataset"]
         self.status_prefix = self.ctx["status_prefix"]
         self.app = self.ctx["app"]
         self.environment = self.ctx["environment"]

--- a/pkg/workloads/spark_job/spark_job.py
+++ b/pkg/workloads/spark_job/spark_job.py
@@ -110,7 +110,7 @@ def validate_dataset(ctx, raw_df, features_to_validate):
 
 def write_raw_dataset(df, ctx, spark):
     logger.info("Caching {} data (version: {})".format(ctx.app["name"], ctx.dataset_version))
-    acc, df = spark_util.count_rows(df, spark)
+    acc, df = spark_util.accumulate_count(df, spark)
     df.write.mode("overwrite").parquet(aws.s3a_path(ctx.bucket, ctx.raw_dataset["key"]))
     return acc.value
 

--- a/pkg/workloads/spark_job/spark_job.py
+++ b/pkg/workloads/spark_job/spark_job.py
@@ -20,7 +20,7 @@ import traceback
 
 from pyspark.sql import SparkSession
 
-from lib import util
+from lib import util, aws
 from lib.context import Context
 from lib.log import get_logger
 from lib.exceptions import UserException, CortexException, UserRuntimeException
@@ -91,69 +91,79 @@ def parse_args(args):
     )
 
 
+def validate_dataset(ctx, raw_df, features_to_validate):
+    total_row_count = aws.read_json_from_s3(ctx.raw_dataset["metadata_key"], ctx.bucket)[
+        "dataset_size"
+    ]
+    conditions_dict = spark_util.value_check_data(ctx, raw_df, features_to_validate)
+
+    if len(conditions_dict) > 0:
+        for column, cond_count_list in conditions_dict.items():
+            for condition, fail_count in cond_count_list:
+                logger.error(
+                    "Data validation {} has been violated in {}/{} samples".format(
+                        condition, fail_count, total_row_count
+                    )
+                )
+        raise UserException("raw feature validations failed")
+
+
+def write_raw_dataset(df, ctx, spark):
+    logger.info("Caching {} data (version: {})".format(ctx.app["name"], ctx.dataset_version))
+    acc, df = spark_util.count_rows(df, spark)
+    df.write.mode("overwrite").parquet(aws.s3a_path(ctx.bucket, ctx.raw_dataset["key"]))
+    return acc.value
+
+
+def drop_null_and_write(ingest_df, ctx, spark):
+    full_dataset_size = ingest_df.count()
+    logger.info("Dropping any rows that contain null values")
+    ingest_df = ingest_df.dropna()
+    written_count = write_raw_dataset(ingest_df, ctx, spark)
+    metadata = {"dataset_size": written_count}
+    aws.upload_json_to_s3(metadata, ctx.raw_dataset["metadata_key"], ctx.bucket)
+    logger.info(
+        "{} rows read, {} rows dropped, {} rows ingested".format(
+            full_dataset_size, full_dataset_size - written_count, written_count
+        )
+    )
+
+
 def ingest_raw_dataset(spark, ctx, features_to_validate, should_ingest):
     if should_ingest:
         features_to_validate = list(ctx.rf_id_map.keys())
 
-    if len(features_to_validate) > 0:
-        feature_resources_to_validate = [ctx.rf_id_map[f] for f in features_to_validate]
-        ctx.upload_resource_status_start(*feature_resources_to_validate)
-        try:
-            if should_ingest:
-                logger.info("Ingesting")
-                logger.info(
-                    "Ingesting {} data from {}".format(
-                        ctx.app["name"], ctx.environment["data"]["path"]
-                    )
-                )
-                ingest_df = spark_util.ingest(ctx, spark)
-                full_dataset_counter = ingest_df.count()
-                if ctx.environment["data"].get("drop_null"):
-                    ingest_df = ingest_df.dropna()
-                    logger.info("Dropping any rows that contain null values")
-                    write_dataset_counter = ingest_df.count()
+    if len(features_to_validate) == 0:
+        logger.info("Reading {} data (version: {})".format(ctx.app["name"], ctx.dataset_version))
+        return spark_util.read_raw_dataset(ctx, spark)
 
-                logger.info(
-                    "Caching {} data (version: {})".format(ctx.app["name"], ctx.dataset_version)
-                )
-                spark_util.write_raw_dataset(ingest_df, ctx)
-
-                if ctx.environment["data"].get("drop_null"):
-                    logger.info(
-                        "{} rows read, {} rows dropped, {} rows ingested".format(
-                            full_dataset_counter,
-                            full_dataset_counter - write_dataset_counter,
-                            write_dataset_counter,
-                        )
-                    )
-                else:
-                    logger.info("{} rows ingested".format(full_dataset_counter))
+    feature_resources_to_validate = [ctx.rf_id_map[f] for f in features_to_validate]
+    ctx.upload_resource_status_start(*feature_resources_to_validate)
+    try:
+        if should_ingest:
+            logger.info("Ingesting")
             logger.info(
-                "Reading {} data (version: {})".format(ctx.app["name"], ctx.dataset_version)
+                "Ingesting {} data from {}".format(ctx.app["name"], ctx.environment["data"]["path"])
             )
-            raw_df = spark_util.read_raw_dataset(ctx, spark)
-            total_row_count = raw_df.count()
-            conditions_dict = spark_util.value_check_data(ctx, raw_df, features_to_validate)
+            ingest_df = spark_util.ingest(ctx, spark)
 
-            if len(conditions_dict) > 0:
-                for column, cond_count_list in conditions_dict.items():
-                    for condition, fail_count in cond_count_list:
-                        logger.error(
-                            "Data validation {} has been violated in {}/{} samples".format(
-                                condition, fail_count, total_row_count
-                            )
-                        )
-                raise UserException("raw feature validations failed")
-        except:
-            ctx.upload_resource_status_failed(*feature_resources_to_validate)
-            raise
-        ctx.upload_resource_status_success(*feature_resources_to_validate)
-        logger.info("First {} samples:".format(3))
-        show_df(raw_df, ctx, 3)
-    else:
+            if ctx.environment["data"].get("drop_null"):
+                drop_null_and_write(ingest_df, ctx, spark)
+            else:
+                written_count = write_raw_dataset(ingest_df, ctx, spark)
+                metadata = {"dataset_size": written_count}
+                aws.upload_json_to_s3(metadata, ctx.raw_dataset["metadata_key"], ctx.bucket)
+                logger.info("{} rows ingested".format(written_count))
+
         logger.info("Reading {} data (version: {})".format(ctx.app["name"], ctx.dataset_version))
         raw_df = spark_util.read_raw_dataset(ctx, spark)
-        spark_util.value_check_data(ctx, raw_df, features_to_validate)
+        validate_dataset(ctx, raw_df, features_to_validate)
+    except:
+        ctx.upload_resource_status_failed(*feature_resources_to_validate)
+        raise
+    ctx.upload_resource_status_success(*feature_resources_to_validate)
+    logger.info("First {} samples:".format(3))
+    show_df(raw_df, ctx, 3)
 
     return raw_df
 
@@ -256,7 +266,7 @@ def create_training_datasets(spark, ctx, training_datasets, accumulated_df):
                 td_resource["model_name"], accumulated_df, ctx, spark
             )
             logger.info("Generating {}".format(", ".join(td_resource["aliases"])))
-            spark_util.write_training_data(td_resource["model_name"], accumulated_df, ctx)
+            spark_util.write_training_data(td_resource["model_name"], accumulated_df, ctx, spark)
         except:
             ctx.upload_resource_status_failed(td_resource)
             raise

--- a/pkg/workloads/spark_job/spark_util.py
+++ b/pkg/workloads/spark_job/spark_util.py
@@ -49,7 +49,7 @@ CORTEX_TYPE_TO_ACCEPTABLE_SPARK_TYPES = {
 }
 
 
-def count_rows(df, spark):
+def accumulate_count(df, spark):
     acc = df._sc.accumulator(0)
     first_column_schema = df.schema[0]
     col_name = first_column_schema.name
@@ -84,12 +84,12 @@ def write_training_data(model_name, df, ctx, spark):
     eval_ratio = model["data_partition_ratio"]["evaluation"]
     [train_df, eval_df] = df.randomSplit([train_ratio, eval_ratio])
 
-    train_df_acc, train_df = count_rows(train_df, spark)
+    train_df_acc, train_df = accumulate_count(train_df, spark)
     train_df.write.mode("overwrite").format("tfrecords").option("recordType", "Example").save(
         aws.s3a_path(ctx.bucket, training_dataset["train_key"])
     )
 
-    eval_df_acc, eval_df = count_rows(eval_df, spark)
+    eval_df_acc, eval_df = accumulate_count(eval_df, spark)
     eval_df.write.mode("overwrite").format("tfrecords").option("recordType", "Example").save(
         aws.s3a_path(ctx.bucket, training_dataset["eval_key"])
     )

--- a/pkg/workloads/spark_job/spark_util.py
+++ b/pkg/workloads/spark_job/spark_util.py
@@ -49,12 +49,23 @@ CORTEX_TYPE_TO_ACCEPTABLE_SPARK_TYPES = {
 }
 
 
+def count_rows(df, spark):
+    acc = df._sc.accumulator(0)
+    first_column_schema = df.schema[0]
+    col_name = first_column_schema.name
+    col_type = first_column_schema.dataType
+
+    def _acc_func(val):
+        acc.add(1)
+        return val
+
+    acc_func = F.udf(_acc_func, col_type)
+    df = df.withColumn(col_name, acc_func(F.col(col_name)))
+    return acc, df
+
+
 def read_raw_dataset(ctx, spark):
-    return spark.read.parquet(aws.s3a_path(ctx.bucket, ctx.raw_dataset_key))
-
-
-def write_raw_dataset(df, ctx):
-    df.write.mode("overwrite").parquet(aws.s3a_path(ctx.bucket, ctx.raw_dataset_key))
+    return spark.read.parquet(aws.s3a_path(ctx.bucket, ctx.raw_dataset["key"]))
 
 
 def log_df_schema(df, logger_func=logger.info):
@@ -62,25 +73,30 @@ def log_df_schema(df, logger_func=logger.info):
         logger_func(line)
 
 
-def write_training_data(model_name, df, ctx):
+def write_training_data(model_name, df, ctx, spark):
     model = ctx.models[model_name]
     training_dataset = model["dataset"]
     feature_names = model["features"] + [model["target"]] + model["training_features"]
 
     df = df.select(*feature_names)
 
-    metadata = {"dataset_size": df.count()}
-    aws.upload_json_to_s3(metadata, training_dataset["metadata_key"], ctx.bucket)
-
     train_ratio = model["data_partition_ratio"]["training"]
     eval_ratio = model["data_partition_ratio"]["evaluation"]
     [train_df, eval_df] = df.randomSplit([train_ratio, eval_ratio])
+
+    train_df_acc, train_df = count_rows(train_df, spark)
     train_df.write.mode("overwrite").format("tfrecords").option("recordType", "Example").save(
         aws.s3a_path(ctx.bucket, training_dataset["train_key"])
     )
+
+    eval_df_acc, eval_df = count_rows(eval_df, spark)
     eval_df.write.mode("overwrite").format("tfrecords").option("recordType", "Example").save(
         aws.s3a_path(ctx.bucket, training_dataset["eval_key"])
     )
+
+    metadata = {"training_size": train_df_acc.value, "eval_size": eval_df_acc.value}
+    aws.upload_json_to_s3(metadata, training_dataset["metadata_key"], ctx.bucket)
+
     return df
 
 

--- a/pkg/workloads/tf_train/train_util.py
+++ b/pkg/workloads/tf_train/train_util.py
@@ -139,11 +139,7 @@ def train(model_name, model_impl, ctx, model_dir):
     train_num_steps = model["training"]["num_steps"]
     if model["training"]["num_epochs"]:
         train_num_steps = (
-            math.ceil(
-                dataset_metadata["dataset_size"]
-                * model["data_partition_ratio"]["training"]
-                / float(model["training"]["batch_size"])
-            )
+            math.ceil(dataset_metadata["training_size"] / float(model["training"]["batch_size"]))
             * model["training"]["num_epochs"]
         )
 
@@ -152,11 +148,7 @@ def train(model_name, model_impl, ctx, model_dir):
     eval_num_steps = model["evaluation"]["num_steps"]
     if model["evaluation"]["num_epochs"]:
         eval_num_steps = (
-            math.ceil(
-                dataset_metadata["dataset_size"]
-                * model["data_partition_ratio"]["evaluation"]
-                / float(model["evaluation"]["batch_size"])
-            )
+            math.ceil(dataset_metadata["eval_size"] / float(model["evaluation"]["batch_size"]))
             * model["evaluation"]["num_epochs"]
         )
 


### PR DESCRIPTION
Randomsplit doesn't split the partition the data exactly. 

If you had 150 rows and had 0.9:0.1 partitioning ratio you are not guaranteed to split the data 135:15. It is approximate.

---
Checklist:
- [X] Test end to end manually (e.g. rebuild registry/operator and run `cx refresh` in an example folder)
- [X] Run automated tests (`./build/test.sh`)
- [X] Update documentation
- [X] Update examples and `cx init`
- [x] Alert team if dev environment changed
- [x] Cherry-pick bugfixes into release branches
- [ ] Delete the branch once it's merged
