### PR TITLE
Revert "Use Istio CNI insead of init containers (#284)"

### DIFF
--- a/manager/install_cortex.sh
+++ b/manager/install_cortex.sh
@@ -97,9 +97,6 @@ function setup_istio() {
   done
 
   echo -n "."
-  helm template istio-manifests/istio-cni --name istio-cni --namespace kube-system | kubectl apply -f - >/dev/null
-  echo -n "."
-
   envsubst < manifests/istio.yaml | helm template istio-manifests/istio --values - --name istio --namespace istio-system | kubectl apply -f - >/dev/null
 }
 

--- a/manager/manifests/istio.yaml
+++ b/manager/manifests/istio.yaml
@@ -14,7 +14,6 @@
 
 # Images which are not mirrored in Cortex Dockerhub repo (because the Helm template does not currently support overriding):
 #   - docker.io/istio/kubectl
-#   - docker.io/istio/install-cni
 
 gateways:
   enabled: true
@@ -85,11 +84,6 @@ sidecarInjectorWebhook:
         workloadType: api
     - matchLabels:
         workloadType: operator
-
-istio_cni:
-  enabled: true
-  excludeNamespaces:
-    - istio-system
 
 galley:
   image: $CORTEX_IMAGE_ISTIO_GALLEY


### PR DESCRIPTION
Closes #289 

This reverts commit 3a004cad27253ce0c89731bd9d523bddf0676d35.

---
Checklist:
- [x] Run `make test` and `make lint`
- [x] Test end to end manually (e.g. build/push all images, restart operator, and run `cx refresh`)
- [x] Update examples
- [x] Update documentation (add any new files to `summary.md`)
- [ ] Merge to master
- [x] Cherry-pick into release branches if it's a bugfix
- [x] Check [gitbook](https://docs.cortex.dev/v/master/) that docs look good and links function properly
- [x] Alert team if dev environment changed
- [ ] Delete the branch once it's merged
