### PR TITLE
fixed misplaced comma in a jupyter notebook file in an example

### DIFF
--- a/examples/tensorflow/sentiment-analyzer/bert.ipynb
+++ b/examples/tensorflow/sentiment-analyzer/bert.ipynb
@@ -48,10 +48,10 @@
         "colab_type": "text"
       },
       "source": [
-        "#Predicting Movie Review Sentiment with BERT on TF Hub"
+        "#Predicting Movie Review Sentiment with BERT on TF Hub",
         "\n",
         "_WARNING: you are on the master branch, please refer to the examples on the branch that matches your `cortex version`_\n",
-        "\n",
+        "\n"
       ]
     },
     {


### PR DESCRIPTION
there's a single misplaced comma in a jupyter notebook file preventing it from being opened and I moved it back... that's it.