### PR TITLE
Assert API version before inspecting args in python

### DIFF
--- a/pkg/workloads/cortex/serve/serve.py
+++ b/pkg/workloads/cortex/serve/serve.py
@@ -39,7 +39,6 @@ local_cache = {"api": None, "predictor_impl": None, "client": None, "class_set":
 
 
 def start(args):
-    assert_api_version()
     storage = S3(bucket=os.environ["CORTEX_BUCKET"], region=os.environ["AWS_REGION"])
     try:
         raw_api_spec = get_spec(storage, args.cache_dir, args.spec)
@@ -185,6 +184,7 @@ def extract_waitress_params(config):
 
 
 def main():
+    assert_api_version()
     parser = argparse.ArgumentParser()
     na = parser.add_argument_group("required named arguments")
     na.add_argument("--port", type=int, required=True, help="port (on localhost) to use")


### PR DESCRIPTION
---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
