### PR TITLE
Update license plate reader crnn workers_per_replica to 1

### DIFF
--- a/examples/tensorflow/license-plate-reader/cortex.yaml
+++ b/examples/tensorflow/license-plate-reader/cortex.yaml
@@ -29,5 +29,5 @@
   autoscaling:
     min_replicas: 10
     max_replicas: 10
-    workers_per_replica: 4
+    workers_per_replica: 1
     threads_per_worker: 1


### PR DESCRIPTION
Resolves a GPU out of memory issue with multiple workers per replica for the crnn API in the license plate reader example