### PR TITLE
Wait for cloudformation stacks to delete during cluster down

### DIFF
--- a/manager/uninstall.sh
+++ b/manager/uninstall.sh
@@ -20,6 +20,6 @@ EKSCTL_TIMEOUT=45m
 
 echo -e "spinning down the cluster ...\n"
 
-eksctl delete cluster --name=$CORTEX_CLUSTER_NAME --region=$CORTEX_REGION --timeout=$EKSCTL_TIMEOUT
+eksctl delete cluster --wait --name=$CORTEX_CLUSTER_NAME --region=$CORTEX_REGION --timeout=$EKSCTL_TIMEOUT
 
 echo -e "\n✓ please check CloudFormation to ensure that all resources for the ${CORTEX_CLUSTER_NAME} cluster eventually become successfully deleted: https://console.aws.amazon.com/cloudformation/home?region=${CORTEX_REGION}#/stacks?filteringText=-${CORTEX_CLUSTER_NAME}-"


### PR DESCRIPTION
---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)