### PR TITLE
added rolling update to deamonset

### DIFF
--- a/manager/install.sh
+++ b/manager/install.sh
@@ -160,22 +160,16 @@ function main() {
   echo "✓"
 
   echo -n "￮ configuring logging "
-  kubectl -n=default delete --ignore-not-found=true daemonset fluentd >/dev/null 2>&1  # Pods in DaemonSets cannot be modified
-  until [ "$(kubectl -n=default get pods -l app=fluentd -o json | jq -j '.items | length')" -eq "0" ]; do echo -n "."; sleep 2; done
   envsubst < manifests/fluentd.yaml | kubectl apply -f - >/dev/null
   echo "✓"
 
   echo -n "￮ configuring metrics "
-  kubectl -n=default delete --ignore-not-found=true daemonset cloudwatch-agent-statsd >/dev/null 2>&1  # Pods in DaemonSets cannot be modified
-  until [ "$(kubectl -n=default get pods -l name=cloudwatch-agent-statsd -o json | jq -j '.items | length')" -eq "0" ]; do echo -n "."; sleep 2; done
   envsubst < manifests/metrics-server.yaml | kubectl apply -f - >/dev/null
   envsubst < manifests/statsd.yaml | kubectl apply -f - >/dev/null
   echo "✓"
 
   if [[ "$CORTEX_INSTANCE_TYPE" == p* ]] || [[ "$CORTEX_INSTANCE_TYPE" == g* ]]; then
     echo -n "￮ configuring gpu support "
-    kubectl -n=kube-system delete --ignore-not-found=true daemonset nvidia-device-plugin-daemonset >/dev/null 2>&1  # Pods in DaemonSets cannot be modified
-    until [ "$(kubectl -n=kube-system get pods -l name=nvidia-device-plugin-ds -o json | jq -j '.items | length')" -eq "0" ]; do echo -n "."; sleep 2; done
     envsubst < manifests/nvidia.yaml | kubectl apply -f - >/dev/null
     echo "✓"
   fi

--- a/manager/manifests/fluentd.yaml
+++ b/manager/manifests/fluentd.yaml
@@ -176,7 +176,6 @@ spec:
     metadata:
       labels:
         app: fluentd
-        hallo: dummy
     spec:
       serviceAccountName: fluentd
       priorityClassName: fluentd

--- a/manager/manifests/fluentd.yaml
+++ b/manager/manifests/fluentd.yaml
@@ -168,10 +168,15 @@ metadata:
   name: fluentd
   namespace: default
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
         app: fluentd
+        hallo: dummy
     spec:
       serviceAccountName: fluentd
       priorityClassName: fluentd

--- a/manager/manifests/nvidia.yaml
+++ b/manager/manifests/nvidia.yaml
@@ -28,7 +28,6 @@ metadata:
   name: nvidia-device-plugin-daemonset
   namespace: kube-system
 spec:
-
   selector:
     matchLabels:
       name: nvidia-device-plugin-ds

--- a/manager/manifests/nvidia.yaml
+++ b/manager/manifests/nvidia.yaml
@@ -28,11 +28,14 @@ metadata:
   name: nvidia-device-plugin-daemonset
   namespace: kube-system
 spec:
+
   selector:
     matchLabels:
       name: nvidia-device-plugin-ds
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       # This annotation is deprecated. Kept here for backward compatibility

--- a/manager/manifests/statsd.yaml
+++ b/manager/manifests/statsd.yaml
@@ -66,7 +66,6 @@ spec:
     metadata:
       labels:
         name: cloudwatch-agent-statsd
-        hallo: dummy
     spec:
       priorityClassName: statsd
       containers:

--- a/manager/manifests/statsd.yaml
+++ b/manager/manifests/statsd.yaml
@@ -55,6 +55,10 @@ metadata:
   name: cloudwatch-agent-statsd
   namespace: default
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       name: cloudwatch-agent-statsd
@@ -62,6 +66,7 @@ spec:
     metadata:
       labels:
         name: cloudwatch-agent-statsd
+        hallo: dummy
     spec:
       priorityClassName: statsd
       containers:


### PR DESCRIPTION
 updated cloudwatch-agent-statsd, fluentd and nvidia to perform rolling update in cluster update command. 

closes #630

---

checklist:

- [ x] run `make test` and `make lint`
- [x ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ x] update examples
- [x ] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex.dev/v/master) after merging)
- [x ] cherry-pick into release branches if applicable
- [ x] alert the dev team if the dev environment changed
