### PR TITLE
Fix non-existent docker.sock

### DIFF
--- a/manager/manifests/operator.yaml
+++ b/manager/manifests/operator.yaml
@@ -75,10 +75,16 @@ spec:
         volumeMounts:
           - name: cluster-config
             mountPath: /configs/cluster
+          - name: docker-client
+            mountPath: /var/run/docker.sock
       volumes:
         - name: cluster-config
           configMap:
             name: cluster-config
+        - name: docker-client
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
 
 ---
 

--- a/pkg/operator/operator/validations.go
+++ b/pkg/operator/operator/validations.go
@@ -822,7 +822,7 @@ func validateDockerImagePath(image string) error {
 		}
 	}
 
-	client, err := dockerclient.NewEnvClient()
+	client, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When the operator is running as a pod (and not locally, with `make devstart`), the container doesn't have access to the docker socket and therefore the validation process fails if any other image other than the default one is used for a given API. The returned error is:
```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

Also, the client API negotiating algorithm has to be used, because otherwise, the docker client returns this error:
```
Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
```

Related to #948.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
