### PR TITLE
Set istio pilot max replicas to 2

### DIFF
--- a/manager/manifests/istio-values.yaml
+++ b/manager/manifests/istio-values.yaml
@@ -130,6 +130,8 @@ pilot:
   image: $CORTEX_IMAGE_ISTIO_PILOT
   enabled: true
   sidecar: false
+  autoscaleMin: 1
+  autoscaleMax: 2
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
Sometimes istio pilot autoscales to 4 replicas after repeated use of `cortex cluster update`