### PR TITLE
Validate target_replica_concurrency <= max_replica_concurrency

### DIFF
--- a/pkg/types/spec/errors.go
+++ b/pkg/types/spec/errors.go
@@ -33,6 +33,7 @@ const (
 	ErrDuplicateEndpoint                    = "spec.duplicate_endpoint"
 	ErrSpecifyAllOrNone                     = "spec.specify_all_or_none"
 	ErrOneOfPrerequisitesNotDefined         = "spec.one_of_prerequisites_not_defined"
+	ErrConfigGreaterThanOtherConfig         = "spec.config_greater_than_other_config"
 	ErrMinReplicasGreaterThanMax            = "spec.min_replicas_greater_than_max"
 	ErrInitReplicasGreaterThanMax           = "spec.init_replicas_greater_than_max"
 	ErrInitReplicasLessThanMin              = "spec.init_replicas_less_than_min"
@@ -120,6 +121,13 @@ func ErrorOneOfPrerequisitesNotDefined(argName string, prerequisite string, prer
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrOneOfPrerequisitesNotDefined,
 		Message: message,
+	})
+}
+
+func ErrorConfigGreaterThanOtherConfig(tooBigKey string, tooBigVal interface{}, tooSmallKey string, tooSmallVal interface{}) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrConfigGreaterThanOtherConfig,
+		Message: fmt.Sprintf("%s (%s) cannot be greater than %s (%s)", tooBigKey, s.UserStr(tooBigVal), tooSmallKey, s.UserStr(tooSmallVal)),
 	})
 }
 

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -765,6 +765,10 @@ func validateAutoscaling(autoscaling *userconfig.Autoscaling) error {
 		autoscaling.TargetReplicaConcurrency = pointer.Float64(float64(autoscaling.WorkersPerReplica * autoscaling.ThreadsPerWorker))
 	}
 
+	if *autoscaling.TargetReplicaConcurrency > float64(autoscaling.MaxReplicaConcurrency) {
+		return ErrorConfigGreaterThanOtherConfig(userconfig.TargetReplicaConcurrencyKey, *autoscaling.TargetReplicaConcurrency, userconfig.MaxReplicaConcurrencyKey, autoscaling.MaxReplicaConcurrency)
+	}
+
 	if autoscaling.MinReplicas > autoscaling.MaxReplicas {
 		return ErrorMinReplicasGreaterThanMax(autoscaling.MinReplicas, autoscaling.MaxReplicas)
 	}


### PR DESCRIPTION
closes #933

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
