### PR TITLE
Use math.MaxUint16 in port validation

### DIFF
--- a/cli/local/validations.go
+++ b/cli/local/validations.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"path/filepath"
 	"runtime"
@@ -276,7 +277,7 @@ func findTheNextAvailablePort(blackListedPorts []int) (int, error) {
 		blackListedSet[port] = struct{}{}
 	}
 
-	for _startingPort <= 65535 {
+	for _startingPort <= math.MaxUint16 {
 		if _, ok := blackListedSet[_startingPort]; ok {
 			_startingPort++
 			continue

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -67,7 +67,7 @@ func apiValidation(provider types.ProviderType) *cr.StructValidation {
 				StructField: "LocalPort",
 				IntPtrValidation: &cr.IntPtrValidation{
 					GreaterThan:       pointer.Int(0),
-					LessThanOrEqualTo: pointer.Int(65535),
+					LessThanOrEqualTo: pointer.Int(math.MaxUint16),
 				},
 			},
 			predictorValidation(),


### PR DESCRIPTION
closes #1028

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
