### PR TITLE
Search all environments for AWS credential defaults

### DIFF
--- a/cli/cmd/lib_cli_config.go
+++ b/cli/cmd/lib_cli_config.go
@@ -641,6 +641,25 @@ func getEnvConfigDefaults(envName string) cliconfig.Environment {
 	if defaults.AWSRegion == nil && os.Getenv("AWS_REGION") != "" {
 		defaults.AWSRegion = pointer.String(os.Getenv("AWS_REGION"))
 	}
+
+	if defaults.AWSAccessKeyID == nil && defaults.AWSSecretAccessKey == nil {
+		// search other envs for credentials (favoring the env named "aws", or the last entry in the list)
+		regionWasNil := defaults.AWSRegion == nil
+		cliConfig, _ := readCLIConfig()
+		for _, env := range cliConfig.Environments {
+			if env.AWSAccessKeyID != nil && env.AWSSecretAccessKey != nil {
+				defaults.AWSAccessKeyID = env.AWSAccessKeyID
+				defaults.AWSSecretAccessKey = env.AWSSecretAccessKey
+			}
+			if regionWasNil && env.AWSRegion != nil {
+				defaults.AWSRegion = env.AWSRegion
+			}
+			if env.Name == "aws" {
+				break // favor the env named "aws"
+			}
+		}
+	}
+
 	if defaults.AWSRegion == nil {
 		defaults.AWSRegion = pointer.String("us-east-1")
 	}
@@ -685,6 +704,7 @@ func configureEnv(envName string, fieldsToSkipPrompt cliconfig.Environment) (cli
 	}
 
 	defaults := getEnvConfigDefaults(env.Name)
+
 	switch env.Provider {
 	case types.LocalProviderType:
 		err := promptLocalEnv(&env, defaults)


### PR DESCRIPTION
closes #726

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
