### PR TITLE
Fix inaccessible python packages after Python update w/ Conda

### DIFF
--- a/docs/deployments/python-packages.md
+++ b/docs/deployments/python-packages.md
@@ -78,4 +78,6 @@ conda-forge::pygpu
 
 In situations where both `requirements.txt` and `conda-packages.txt` are provided, Cortex installs Conda packages in `conda-packages.txt` followed by PyPI packages in `requirements.txt`. Conda and Pip package managers install packages and dependencies independently. You may run into situations where Conda and pip package managers install different versions of the same package because they install and resolve dependencies independently from one another. To resolve package version conflicts, it may be in your best interest to specify their exact versions in `conda-packages.txt`.
 
+The current version of Python is `3.6.9`. Updating Python to a different version is possible with Conda, but there are no guarantees the web server will continue functioning correctly. If there's a change in Python's version, the necessary core packages for the web server will get reinstalled.
+
 Check the [best practices](https://www.anaconda.com/using-pip-in-a-conda-environment/) on using `pip` inside `conda`.

--- a/docs/deployments/python-packages.md
+++ b/docs/deployments/python-packages.md
@@ -78,6 +78,6 @@ conda-forge::pygpu
 
 In situations where both `requirements.txt` and `conda-packages.txt` are provided, Cortex installs Conda packages in `conda-packages.txt` followed by PyPI packages in `requirements.txt`. Conda and Pip package managers install packages and dependencies independently. You may run into situations where Conda and pip package managers install different versions of the same package because they install and resolve dependencies independently from one another. To resolve package version conflicts, it may be in your best interest to specify their exact versions in `conda-packages.txt`.
 
-The current version of Python is `3.6.9`. Updating Python to a different version is possible with Conda, but there are no guarantees the web server will continue functioning correctly. If there's a change in Python's version, the necessary core packages for the web server will get reinstalled.
+The current version of Python is `3.6.9`. Updating Python to a different version is possible with Conda, but there are no guarantees the web server will continue functioning correctly. If there's a change in Python's version, the necessary core packages for the web server will get reinstalled. Any other Python packages that came with the image won't be accessible during the runtime.
 
 Check the [best practices](https://www.anaconda.com/using-pip-in-a-conda-environment/) on using `pip` inside `conda`.

--- a/docs/deployments/python-packages.md
+++ b/docs/deployments/python-packages.md
@@ -78,6 +78,6 @@ conda-forge::pygpu
 
 In situations where both `requirements.txt` and `conda-packages.txt` are provided, Cortex installs Conda packages in `conda-packages.txt` followed by PyPI packages in `requirements.txt`. Conda and Pip package managers install packages and dependencies independently. You may run into situations where Conda and pip package managers install different versions of the same package because they install and resolve dependencies independently from one another. To resolve package version conflicts, it may be in your best interest to specify their exact versions in `conda-packages.txt`.
 
-The current version of Python is `3.6.9`. Updating Python to a different version is possible with Conda, but there are no guarantees the web server will continue functioning correctly. If there's a change in Python's version, the necessary core packages for the web server will get reinstalled. Any other Python packages that came with the image won't be accessible during the runtime.
+The current version of Python is `3.6.9`. Updating Python to a different version is possible with Conda, but there are no guarantees that Cortex's web server will continue functioning correctly. If there's a change in Python's version, the necessary core packages for the web server will be reinstalled. If you are using a custom base image, any other Python packages that are built in to the image won't be accessible at runtime.
 
 Check the [best practices](https://www.anaconda.com/using-pip-in-a-conda-environment/) on using `pip` inside `conda`.

--- a/pkg/workloads/cortex/serve/run.sh
+++ b/pkg/workloads/cortex/serve/run.sh
@@ -42,19 +42,18 @@ fi
 
 # install from conda-packages.txt
 if [ -f "/mnt/project/conda-packages.txt" ]; then
-    PYVERSION='echo $(python -c "import sys; v=sys.version_info[:2]; print(\"{}.{}\".format(*v));")'
-    OLDPYVERSION=$(eval $PYVERSION)
+    py_version_cmd='echo $(python -c "import sys; v=sys.version_info[:2]; print(\"{}.{}\".format(*v));")'
+    old_py_version=$(eval $py_version_cmd)
 
     conda install --file /mnt/project/conda-packages.txt
-    NEWPYVERSION=$(eval $PYVERSION)
+    new_py_version=$(eval $py_version_cmd)
 
-    # reinstall core packages if new version of python is used
-    if [ $OLDPYVERSION != $NEWPYVERSION ]; then
-        echo "user has updated the Python version from $OLDPYVERSION to $NEWPYVERSION; this may break the web server"
+    # reinstall core packages if Python version has changed
+    if [ $old_py_version != $new_py_version ]; then
+        echo "warning: you have changed the Python version from $old_py_version to $new_py_version; this may break Cortex's web server"
         echo "reinstalling core packages ..."
         pip --no-cache-dir install -r /src/cortex/serve/requirements.txt
-        # no longer required
-        rm -rf $CONDA_PREFIX/lib/python${OLDPYVERSION}
+        rm -rf $CONDA_PREFIX/lib/python${old_py_version}  # previous python is no longer needed
     fi
 fi
 

--- a/pkg/workloads/cortex/serve/run.sh
+++ b/pkg/workloads/cortex/serve/run.sh
@@ -48,11 +48,10 @@ if [ -f "/mnt/project/conda-packages.txt" ]; then
     conda install --file /mnt/project/conda-packages.txt
     NEWPYVERSION=$(eval $PYVERSION)
 
-    echo "old: ${OLDPYVERSION}"
-    echo "new: ${NEWPYVERSION}"
-
     # reinstall core packages if new version of python is used
     if [ $OLDPYVERSION != $NEWPYVERSION ]; then
+        echo "user has updated the Python version from $OLDPYVERSION to $NEWPYVERSION; this may break the web server"
+        echo "reinstalling core packages ..."
         pip --no-cache-dir install -r /src/cortex/serve/requirements.txt
         # no longer required
         rm -rf $CONDA_PREFIX/lib/python${OLDPYVERSION}

--- a/pkg/workloads/cortex/serve/run.sh
+++ b/pkg/workloads/cortex/serve/run.sh
@@ -42,7 +42,21 @@ fi
 
 # install from conda-packages.txt
 if [ -f "/mnt/project/conda-packages.txt" ]; then
+    PYVERSION='echo $(python -c "import sys; v=sys.version_info[:2]; print(\"{}.{}\".format(*v));")'
+    OLDPYVERSION=$(eval $PYVERSION)
+
     conda install --file /mnt/project/conda-packages.txt
+    NEWPYVERSION=$(eval $PYVERSION)
+
+    echo "old: ${OLDPYVERSION}"
+    echo "new: ${NEWPYVERSION}"
+
+    # reinstall core packages if new version of python is used
+    if [ $OLDPYVERSION != $NEWPYVERSION ]; then
+        pip --no-cache-dir install -r /src/cortex/serve/requirements.txt
+        # no longer required
+        rm -rf $CONDA_PREFIX/lib/python${OLDPYVERSION}
+    fi
 fi
 
 # install pip packages


### PR DESCRIPTION
Closes #1051.

When `conda-packages.txt` is used to update Python to a different version (`major.minor` version), all packages that were previously installed on the image will no longer be accessible. This is not because they are removed, but because they reside in a different folder named after the Python's version.

Since most packages are built for each `major.minor` version of Python, it's just better to reinstall them if a change of version is detected. This is something that should definitely not be encouraged, because it may very well break the web server. The web server is currently running on Python 3.6.9. By moving it to a different version, its stability cannot be guaranteed.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex.dev/v/master) after merging)
