### PR TITLE
Add git package to serving images

### DIFF
--- a/images/onnx-predictor-cpu/Dockerfile
+++ b/images/onnx-predictor-cpu/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
         pkg-config \
         software-properties-common \
         curl \
+        git \
         unzip \
         zlib1g-dev \
         locales \

--- a/images/onnx-predictor-gpu/Dockerfile
+++ b/images/onnx-predictor-gpu/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
         pkg-config \
         software-properties-common \
         curl \
+        git \
         unzip \
         zlib1g-dev \
         locales \

--- a/images/python-predictor-cpu/Dockerfile
+++ b/images/python-predictor-cpu/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
         pkg-config \
         software-properties-common \
         curl \
+        git \
         unzip \
         zlib1g-dev \
         locales \

--- a/images/python-predictor-gpu/Dockerfile
+++ b/images/python-predictor-gpu/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
         pkg-config \
         software-properties-common \
         curl \
+        git \
         unzip \
         zlib1g-dev \
         locales \

--- a/images/tensorflow-predictor/Dockerfile
+++ b/images/tensorflow-predictor/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
         pkg-config \
         software-properties-common \
         curl \
+        git \
         unzip \
         zlib1g-dev \
         locales \


### PR DESCRIPTION
The git package may be required when installing pip packages. Sometimes it's required even for pip packages that are listed on PyPi (that apparently don't need git) because they may use git for their dependencies in their `setup.py` config.

Adding this in at a user's request. This package adds 40MB of dependencies.

---

checklist:

- [x] run `make test` and `make lint`
