### PR TITLE
Use the function defined by the library instead, remove unnecessary assignments

### DIFF
--- a/pkg/lib/k8s/configmap.go
+++ b/pkg/lib/k8s/configmap.go
@@ -18,11 +18,10 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 )
 
 var _configMapTypeMeta = kmeta.TypeMeta{
@@ -87,6 +86,7 @@ func (c *Client) GetConfigMap(name string) (*kcore.ConfigMap, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	configMap.TypeMeta = _configMapTypeMeta
 	return configMap, nil
 }
 
@@ -120,12 +120,15 @@ func (c *Client) ListConfigMaps(opts *kmeta.ListOptions) ([]kcore.ConfigMap, err
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range configMapList.Items {
+		configMapList.Items[i].TypeMeta = _configMapTypeMeta
+	}
 	return configMapList.Items, nil
 }
 
-func (c *Client) ListConfigMapsByLabels(labelSelector map[string]string) ([]kcore.ConfigMap, error) {
+func (c *Client) ListConfigMapsByLabels(labels map[string]string) ([]kcore.ConfigMap, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListConfigMaps(opts)
 }

--- a/pkg/lib/k8s/configmap.go
+++ b/pkg/lib/k8s/configmap.go
@@ -18,9 +18,11 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _configMapTypeMeta = kmeta.TypeMeta{
@@ -85,7 +87,6 @@ func (c *Client) GetConfigMap(name string) (*kcore.ConfigMap, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	configMap.TypeMeta = _configMapTypeMeta
 	return configMap, nil
 }
 
@@ -119,15 +120,12 @@ func (c *Client) ListConfigMaps(opts *kmeta.ListOptions) ([]kcore.ConfigMap, err
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range configMapList.Items {
-		configMapList.Items[i].TypeMeta = _configMapTypeMeta
-	}
 	return configMapList.Items, nil
 }
 
-func (c *Client) ListConfigMapsByLabels(labels map[string]string) ([]kcore.ConfigMap, error) {
+func (c *Client) ListConfigMapsByLabels(labelSelector map[string]string) ([]kcore.ConfigMap, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListConfigMaps(opts)
 }

--- a/pkg/lib/k8s/deployment.go
+++ b/pkg/lib/k8s/deployment.go
@@ -20,12 +20,11 @@ import (
 	"time"
 
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kapps "k8s.io/api/apps/v1"
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -134,6 +133,7 @@ func (c *Client) GetDeployment(name string) (*kapps.Deployment, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	deployment.TypeMeta = _deploymentTypeMeta
 	return deployment, nil
 }
 
@@ -156,12 +156,15 @@ func (c *Client) ListDeployments(opts *kmeta.ListOptions) ([]kapps.Deployment, e
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range deploymentList.Items {
+		deploymentList.Items[i].TypeMeta = _deploymentTypeMeta
+	}
 	return deploymentList.Items, nil
 }
 
-func (c *Client) ListDeploymentsByLabels(labelSelector map[string]string) ([]kapps.Deployment, error) {
+func (c *Client) ListDeploymentsByLabels(labels map[string]string) ([]kapps.Deployment, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListDeployments(opts)
 }

--- a/pkg/lib/k8s/deployment.go
+++ b/pkg/lib/k8s/deployment.go
@@ -20,11 +20,13 @@ import (
 	"time"
 
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kapps "k8s.io/api/apps/v1"
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _deploymentTypeMeta = kmeta.TypeMeta{
@@ -132,7 +134,6 @@ func (c *Client) GetDeployment(name string) (*kapps.Deployment, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	deployment.TypeMeta = _deploymentTypeMeta
 	return deployment, nil
 }
 
@@ -155,15 +156,12 @@ func (c *Client) ListDeployments(opts *kmeta.ListOptions) ([]kapps.Deployment, e
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range deploymentList.Items {
-		deploymentList.Items[i].TypeMeta = _deploymentTypeMeta
-	}
 	return deploymentList.Items, nil
 }
 
-func (c *Client) ListDeploymentsByLabels(labels map[string]string) ([]kapps.Deployment, error) {
+func (c *Client) ListDeploymentsByLabels(labelSelector map[string]string) ([]kapps.Deployment, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListDeployments(opts)
 }

--- a/pkg/lib/k8s/hpa.go
+++ b/pkg/lib/k8s/hpa.go
@@ -18,12 +18,11 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kautoscaling "k8s.io/api/autoscaling/v2beta2"
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 )
 
 var _hpaTypeMeta = kmeta.TypeMeta{
@@ -110,6 +109,7 @@ func (c *Client) GetHPA(name string) (*kautoscaling.HorizontalPodAutoscaler, err
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	hpa.TypeMeta = _hpaTypeMeta
 	return hpa, nil
 }
 
@@ -132,12 +132,15 @@ func (c *Client) ListHPAs(opts *kmeta.ListOptions) ([]kautoscaling.HorizontalPod
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range hpaList.Items {
+		hpaList.Items[i].TypeMeta = _hpaTypeMeta
+	}
 	return hpaList.Items, nil
 }
 
-func (c *Client) ListHPAsByLabels(labelSelector map[string]string) ([]kautoscaling.HorizontalPodAutoscaler, error) {
+func (c *Client) ListHPAsByLabels(labels map[string]string) ([]kautoscaling.HorizontalPodAutoscaler, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListHPAs(opts)
 }

--- a/pkg/lib/k8s/hpa.go
+++ b/pkg/lib/k8s/hpa.go
@@ -18,10 +18,12 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kautoscaling "k8s.io/api/autoscaling/v2beta2"
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _hpaTypeMeta = kmeta.TypeMeta{
@@ -108,7 +110,6 @@ func (c *Client) GetHPA(name string) (*kautoscaling.HorizontalPodAutoscaler, err
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	hpa.TypeMeta = _hpaTypeMeta
 	return hpa, nil
 }
 
@@ -131,15 +132,12 @@ func (c *Client) ListHPAs(opts *kmeta.ListOptions) ([]kautoscaling.HorizontalPod
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range hpaList.Items {
-		hpaList.Items[i].TypeMeta = _hpaTypeMeta
-	}
 	return hpaList.Items, nil
 }
 
-func (c *Client) ListHPAsByLabels(labels map[string]string) ([]kautoscaling.HorizontalPodAutoscaler, error) {
+func (c *Client) ListHPAsByLabels(labelSelector map[string]string) ([]kautoscaling.HorizontalPodAutoscaler, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListHPAs(opts)
 }

--- a/pkg/lib/k8s/ingress.go
+++ b/pkg/lib/k8s/ingress.go
@@ -18,10 +18,12 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kextensions "k8s.io/api/extensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _ingressTypeMeta = kmeta.TypeMeta{
@@ -114,7 +116,6 @@ func (c *Client) GetIngress(name string) (*kextensions.Ingress, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	ingress.TypeMeta = _ingressTypeMeta
 	return ingress, nil
 }
 
@@ -137,15 +138,12 @@ func (c *Client) ListIngresses(opts *kmeta.ListOptions) ([]kextensions.Ingress, 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range ingressList.Items {
-		ingressList.Items[i].TypeMeta = _ingressTypeMeta
-	}
 	return ingressList.Items, nil
 }
 
-func (c *Client) ListIngressesByLabels(labels map[string]string) ([]kextensions.Ingress, error) {
+func (c *Client) ListIngressesByLabels(labelSelector map[string]string) ([]kextensions.Ingress, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListIngresses(opts)
 }

--- a/pkg/lib/k8s/ingress.go
+++ b/pkg/lib/k8s/ingress.go
@@ -18,11 +18,10 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kextensions "k8s.io/api/extensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -116,6 +115,7 @@ func (c *Client) GetIngress(name string) (*kextensions.Ingress, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	ingress.TypeMeta = _ingressTypeMeta
 	return ingress, nil
 }
 
@@ -138,12 +138,15 @@ func (c *Client) ListIngresses(opts *kmeta.ListOptions) ([]kextensions.Ingress, 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range ingressList.Items {
+		ingressList.Items[i].TypeMeta = _ingressTypeMeta
+	}
 	return ingressList.Items, nil
 }
 
-func (c *Client) ListIngressesByLabels(labelSelector map[string]string) ([]kextensions.Ingress, error) {
+func (c *Client) ListIngressesByLabels(labels map[string]string) ([]kextensions.Ingress, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListIngresses(opts)
 }

--- a/pkg/lib/k8s/job.go
+++ b/pkg/lib/k8s/job.go
@@ -18,10 +18,12 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kbatch "k8s.io/api/batch/v1"
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _jobTypeMeta = kmeta.TypeMeta{
@@ -105,7 +107,6 @@ func (c *Client) GetJob(name string) (*kbatch.Job, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	job.TypeMeta = _jobTypeMeta
 	return job, nil
 }
 
@@ -128,15 +129,12 @@ func (c *Client) ListJobs(opts *kmeta.ListOptions) ([]kbatch.Job, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range jobList.Items {
-		jobList.Items[i].TypeMeta = _jobTypeMeta
-	}
 	return jobList.Items, nil
 }
 
-func (c *Client) ListJobsByLabels(labels map[string]string) ([]kbatch.Job, error) {
+func (c *Client) ListJobsByLabels(labelSelector map[string]string) ([]kbatch.Job, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListJobs(opts)
 }

--- a/pkg/lib/k8s/job.go
+++ b/pkg/lib/k8s/job.go
@@ -18,12 +18,11 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kbatch "k8s.io/api/batch/v1"
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 )
 
 var _jobTypeMeta = kmeta.TypeMeta{
@@ -107,6 +106,7 @@ func (c *Client) GetJob(name string) (*kbatch.Job, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	job.TypeMeta = _jobTypeMeta
 	return job, nil
 }
 
@@ -129,12 +129,15 @@ func (c *Client) ListJobs(opts *kmeta.ListOptions) ([]kbatch.Job, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range jobList.Items {
+		jobList.Items[i].TypeMeta = _jobTypeMeta
+	}
 	return jobList.Items, nil
 }
 
-func (c *Client) ListJobsByLabels(labelSelector map[string]string) ([]kbatch.Job, error) {
+func (c *Client) ListJobsByLabels(labels map[string]string) ([]kbatch.Job, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListJobs(opts)
 }

--- a/pkg/lib/k8s/k8s.go
+++ b/pkg/lib/k8s/k8s.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/random"
-
 	kresource "k8s.io/apimachinery/pkg/api/resource"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclientdynamic "k8s.io/client-go/dynamic"

--- a/pkg/lib/k8s/k8s.go
+++ b/pkg/lib/k8s/k8s.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/random"
+
 	kresource "k8s.io/apimachinery/pkg/api/resource"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclientdynamic "k8s.io/client-go/dynamic"
@@ -137,19 +138,6 @@ func CPU(cpu string) kresource.Quantity {
 
 func Mem(mem string) kresource.Quantity {
 	return kresource.MustParse(mem)
-}
-
-func LabelSelector(labels map[string]string) string {
-	if len(labels) == 0 {
-		return ""
-	}
-
-	terms := make([]string, 0, len(labels))
-	for key, value := range labels {
-		terms = append(terms, key+"="+value)
-	}
-
-	return strings.Join(terms, ",")
 }
 
 func LabelExistsSelector(labelKeys ...string) string {

--- a/pkg/lib/k8s/node.go
+++ b/pkg/lib/k8s/node.go
@@ -18,8 +18,10 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kcore "k8s.io/api/core/v1"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _nodeTypeMeta = kmeta.TypeMeta{
@@ -35,15 +37,12 @@ func (c *Client) ListNodes(opts *kmeta.ListOptions) ([]kcore.Node, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range nodeList.Items {
-		nodeList.Items[i].TypeMeta = _nodeTypeMeta
-	}
 	return nodeList.Items, nil
 }
 
-func (c *Client) ListNodesByLabels(labels map[string]string) ([]kcore.Node, error) {
+func (c *Client) ListNodesByLabels(labelSelector map[string]string) ([]kcore.Node, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListNodes(opts)
 }

--- a/pkg/lib/k8s/node.go
+++ b/pkg/lib/k8s/node.go
@@ -18,10 +18,9 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kcore "k8s.io/api/core/v1"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 )
 
 var _nodeTypeMeta = kmeta.TypeMeta{
@@ -37,12 +36,15 @@ func (c *Client) ListNodes(opts *kmeta.ListOptions) ([]kcore.Node, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range nodeList.Items {
+		nodeList.Items[i].TypeMeta = _nodeTypeMeta
+	}
 	return nodeList.Items, nil
 }
 
-func (c *Client) ListNodesByLabels(labelSelector map[string]string) ([]kcore.Node, error) {
+func (c *Client) ListNodesByLabels(labels map[string]string) ([]kcore.Node, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListNodes(opts)
 }

--- a/pkg/lib/k8s/pod.go
+++ b/pkg/lib/k8s/pod.go
@@ -23,9 +23,11 @@ import (
 	"time"
 
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	kremotecommand "k8s.io/client-go/tools/remotecommand"
 )
@@ -271,7 +273,6 @@ func (c *Client) GetPod(name string) (*kcore.Pod, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	pod.TypeMeta = _podTypeMeta
 	return pod, nil
 }
 
@@ -294,15 +295,12 @@ func (c *Client) ListPods(opts *kmeta.ListOptions) ([]kcore.Pod, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range podList.Items {
-		podList.Items[i].TypeMeta = _podTypeMeta
-	}
 	return podList.Items, nil
 }
 
-func (c *Client) ListPodsByLabels(labels map[string]string) ([]kcore.Pod, error) {
+func (c *Client) ListPodsByLabels(labelSelector map[string]string) ([]kcore.Pod, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListPods(opts)
 }

--- a/pkg/lib/k8s/pod.go
+++ b/pkg/lib/k8s/pod.go
@@ -23,11 +23,10 @@ import (
 	"time"
 
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	kremotecommand "k8s.io/client-go/tools/remotecommand"
 )
@@ -273,6 +272,7 @@ func (c *Client) GetPod(name string) (*kcore.Pod, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	pod.TypeMeta = _podTypeMeta
 	return pod, nil
 }
 
@@ -295,12 +295,15 @@ func (c *Client) ListPods(opts *kmeta.ListOptions) ([]kcore.Pod, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range podList.Items {
+		podList.Items[i].TypeMeta = _podTypeMeta
+	}
 	return podList.Items, nil
 }
 
-func (c *Client) ListPodsByLabels(labelSelector map[string]string) ([]kcore.Pod, error) {
+func (c *Client) ListPodsByLabels(labels map[string]string) ([]kcore.Pod, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListPods(opts)
 }

--- a/pkg/lib/k8s/service.go
+++ b/pkg/lib/k8s/service.go
@@ -18,11 +18,10 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -105,6 +104,7 @@ func (c *Client) GetService(name string) (*kcore.Service, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	service.TypeMeta = _serviceTypeMeta
 	return service, nil
 }
 
@@ -127,12 +127,15 @@ func (c *Client) ListServices(opts *kmeta.ListOptions) ([]kcore.Service, error) 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	for i := range serviceList.Items {
+		serviceList.Items[i].TypeMeta = _serviceTypeMeta
+	}
 	return serviceList.Items, nil
 }
 
-func (c *Client) ListServicesByLabels(labelSelector map[string]string) ([]kcore.Service, error) {
+func (c *Client) ListServicesByLabels(labels map[string]string) ([]kcore.Service, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListServices(opts)
 }

--- a/pkg/lib/k8s/service.go
+++ b/pkg/lib/k8s/service.go
@@ -18,10 +18,12 @@ package k8s
 
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+
 	kcore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _serviceTypeMeta = kmeta.TypeMeta{
@@ -103,7 +105,6 @@ func (c *Client) GetService(name string) (*kcore.Service, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	service.TypeMeta = _serviceTypeMeta
 	return service, nil
 }
 
@@ -126,15 +127,12 @@ func (c *Client) ListServices(opts *kmeta.ListOptions) ([]kcore.Service, error) 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for i := range serviceList.Items {
-		serviceList.Items[i].TypeMeta = _serviceTypeMeta
-	}
 	return serviceList.Items, nil
 }
 
-func (c *Client) ListServicesByLabels(labels map[string]string) ([]kcore.Service, error) {
+func (c *Client) ListServicesByLabels(labelSelector map[string]string) ([]kcore.Service, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListServices(opts)
 }

--- a/pkg/lib/k8s/virtual_service.go
+++ b/pkg/lib/k8s/virtual_service.go
@@ -20,11 +20,10 @@ import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/sets/strset"
 	"github.com/cortexlabs/cortex/pkg/lib/urls"
-
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	kschema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -187,9 +186,9 @@ func (c *Client) ListVirtualServices(opts *kmeta.ListOptions) ([]kunstructured.U
 	return vsList.Items, nil
 }
 
-func (c *Client) ListVirtualServicesByLabels(labelSelector map[string]string) ([]kunstructured.Unstructured, error) {
+func (c *Client) ListVirtualServicesByLabels(labels map[string]string) ([]kunstructured.Unstructured, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
+		LabelSelector: klabels.SelectorFromSet(labels).String(),
 	}
 	return c.ListVirtualServices(opts)
 }

--- a/pkg/lib/k8s/virtual_service.go
+++ b/pkg/lib/k8s/virtual_service.go
@@ -20,9 +20,11 @@ import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/sets/strset"
 	"github.com/cortexlabs/cortex/pkg/lib/urls"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	kschema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -185,9 +187,9 @@ func (c *Client) ListVirtualServices(opts *kmeta.ListOptions) ([]kunstructured.U
 	return vsList.Items, nil
 }
 
-func (c *Client) ListVirtualServicesByLabels(labels map[string]string) ([]kunstructured.Unstructured, error) {
+func (c *Client) ListVirtualServicesByLabels(labelSelector map[string]string) ([]kunstructured.Unstructured, error) {
 	opts := &kmeta.ListOptions{
-		LabelSelector: LabelSelector(labels),
+		LabelSelector: labels.SelectorFromSet(labelSelector).String(),
 	}
 	return c.ListVirtualServices(opts)
 }

--- a/pkg/operator/operator/memory_capacity.go
+++ b/pkg/operator/operator/memory_capacity.go
@@ -19,10 +19,9 @@ package operator
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/k8s"
 	"github.com/cortexlabs/cortex/pkg/operator/config"
-
 	kresource "k8s.io/apimachinery/pkg/api/resource"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	klabels "k8s.io/apimachinery/pkg/labels"
 )
 
 const _memConfigMapName = "cortex-instance-memory"
@@ -53,7 +52,7 @@ var _nvidiaMemReserve = kresource.MustParse("100Mi")
 
 func getMemoryCapacityFromNodes() (*kresource.Quantity, error) {
 	opts := kmeta.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
+		LabelSelector: klabels.SelectorFromSet(map[string]string{
 			"workload": "true",
 		}).String(),
 	}

--- a/pkg/operator/operator/memory_capacity.go
+++ b/pkg/operator/operator/memory_capacity.go
@@ -19,8 +19,10 @@ package operator
 import (
 	"github.com/cortexlabs/cortex/pkg/lib/k8s"
 	"github.com/cortexlabs/cortex/pkg/operator/config"
+
 	kresource "k8s.io/apimachinery/pkg/api/resource"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const _memConfigMapName = "cortex-instance-memory"
@@ -51,9 +53,9 @@ var _nvidiaMemReserve = kresource.MustParse("100Mi")
 
 func getMemoryCapacityFromNodes() (*kresource.Quantity, error) {
 	opts := kmeta.ListOptions{
-		LabelSelector: k8s.LabelSelector(map[string]string{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"workload": "true",
-		}),
+		}).String(),
 	}
 	nodes, err := config.K8s.ListNodes(&opts)
 	if err != nil {


### PR DESCRIPTION
Use the function defined by the library instead, remove unnecessary assignments, because the object obtained according to the version is specified

closes #<issue ID>

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update examples
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex.dev/v/master) after merging)
- [x] cherry-pick into release branches if applicable
- [x] alert the dev team if the dev environment changed
