### PR TITLE
Add '-y' option to conda install

### DIFF
--- a/pkg/workloads/cortex/serve/run.sh
+++ b/pkg/workloads/cortex/serve/run.sh
@@ -45,7 +45,7 @@ if [ -f "/mnt/project/conda-packages.txt" ]; then
     py_version_cmd='echo $(python -c "import sys; v=sys.version_info[:2]; print(\"{}.{}\".format(*v));")'
     old_py_version=$(eval $py_version_cmd)
 
-    conda install --file /mnt/project/conda-packages.txt
+    conda install -y --file /mnt/project/conda-packages.txt
     new_py_version=$(eval $py_version_cmd)
 
     # reinstall core packages if Python version has changed


### PR DESCRIPTION
closes #1100

Couldn't test locally since it requires re-building the Docker images.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [X] (N/A) update examples
- [X] (N/A) update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
- [ ] cherry-pick into release branches if applicable
- [X] (N/A) alert the dev team if the dev environment changed
