### PR TITLE
Fix shell variable in development makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,27 +49,27 @@ kubectl:
 cluster-up:
 	@$(MAKE) registry-all
 	@$(MAKE) cli
-	@kill $(shell pgrep -f make) >/dev/null 2>&1 || true
+	@kill $($(shell) pgrep -f make) >/dev/null 2>&1 || true
 	@./bin/cortex -c=./dev/config/cluster.yaml cluster up
 	@$(MAKE) kubectl
 
 cluster-up-y:
 	@$(MAKE) registry-all
 	@$(MAKE) cli
-	@kill $(shell pgrep -f make) >/dev/null 2>&1 || true
+	@kill $($(shell) pgrep -f make) >/dev/null 2>&1 || true
 	@./bin/cortex -c=./dev/config/cluster.yaml cluster up --yes
 	@$(MAKE) kubectl
 
 cluster-down:
 	@$(MAKE) manager-local
 	@$(MAKE) cli
-	@kill $(shell pgrep -f make) >/dev/null 2>&1 || true
+	@kill $($(shell) pgrep -f make) >/dev/null 2>&1 || true
 	@./bin/cortex -c=./dev/config/cluster.yaml cluster down
 
 cluster-down-y:
 	@$(MAKE) manager-local
 	@$(MAKE) cli
-	@kill $(shell pgrep -f make) >/dev/null 2>&1 || true
+	@kill $($(shell) pgrep -f make) >/dev/null 2>&1 || true
 	@./bin/cortex -c=./dev/config/cluster.yaml cluster down --yes
 
 cluster-info:
@@ -80,13 +80,13 @@ cluster-info:
 cluster-configure:
 	@$(MAKE) registry-all
 	@$(MAKE) cli
-	@kill $(shell pgrep -f make) >/dev/null 2>&1 || true
+	@kill $($(shell) pgrep -f make) >/dev/null 2>&1 || true
 	@./bin/cortex -c=./dev/config/cluster.yaml cluster configure
 
 cluster-configure-y:
 	@$(MAKE) registry-all
 	@$(MAKE) cli
-	@kill $(shell pgrep -f make) >/dev/null 2>&1 || true
+	@kill $($(shell) pgrep -f make) >/dev/null 2>&1 || true
 	@./bin/cortex -c=./dev/config/cluster.yaml cluster configure --yes
 
 # stop the in-cluster operator

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SHELL := /bin/bash
+shell := /bin/bash
 
 #######
 # Dev #


### PR DESCRIPTION
Any make command that uses the `shell` variable will fail because there's no `shell` variable declared, but a `SHELL` variable with capital letters. Also, every invocation of the shell variable has the dollar sign missing.

These are some examples that will fail: `cluster-up`, `cluster-down`, `cluster-configure`.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
