### PR TITLE
Add shell instruction to serving Dockerfiles

### DIFF
--- a/docs/deployments/system-packages.md
+++ b/docs/deployments/system-packages.md
@@ -57,7 +57,7 @@ Cortex's base Docker images are listed below. Depending on the Cortex Predictor 
 
 Note: the images listed above use the `-slim` suffix; Cortex's default API images are not `-slim`, since they have additional dependencies installed to cover common use cases. If you are building your own Docker image, starting with a `-slim` Predictor image will result in a smaller image size.
 
-The sample Dockerfile below inherits from Cortex's Python CPU serving image, and installs 3 packages. One of them is a system package and the other 2 are Python packages: `tree`, `pandas`, `rdkit`.
+The sample Dockerfile below inherits from Cortex's Python CPU serving image, and installs 3 packages. `tree` is a system package and `pandas` and `rdkit` are Python packages.
 
 <!-- CORTEX_VERSION_BRANCH_STABLE -->
 ```dockerfile

--- a/docs/deployments/system-packages.md
+++ b/docs/deployments/system-packages.md
@@ -57,7 +57,7 @@ Cortex's base Docker images are listed below. Depending on the Cortex Predictor 
 
 Note: the images listed above use the `-slim` suffix; Cortex's default API images are not `-slim`, since they have additional dependencies installed to cover common use cases. If you are building your own Docker image, starting with a `-slim` Predictor image will result in a smaller image size.
 
-The sample Dockerfile below inherits from Cortex's Python CPU serving image and installs the `tree` system package.
+The sample Dockerfile below inherits from Cortex's Python CPU serving image, and installs 3 packages. One of them is a system package and the other 2 are Python packages: `tree`, `pandas`, `rdkit`.
 
 <!-- CORTEX_VERSION_BRANCH_STABLE -->
 ```dockerfile
@@ -68,6 +68,9 @@ FROM cortexlabs/python-predictor-cpu-slim:master
 RUN apt-get update \
     && apt-get install -y tree \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip install pandas \
+    && conda install conda-forge::rdkit
 ```
 
 ### Build and push to a container registry

--- a/docs/deployments/system-packages.md
+++ b/docs/deployments/system-packages.md
@@ -69,8 +69,9 @@ RUN apt-get update \
     && apt-get install -y tree \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pip install pandas \
-    && conda install conda-forge::rdkit
+RUN pip install --no-cache-dir pandas \
+    && conda install -y conda-forge::rdkit \
+    && conda clean -a
 ```
 
 ### Build and push to a container registry

--- a/images/onnx-predictor-cpu/Dockerfile
+++ b/images/onnx-predictor-cpu/Dockerfile
@@ -36,7 +36,9 @@ ENV BASH_ENV=~/.env
 SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt onnxruntime==1.2.0
+RUN pip install --no-cache-dir -r \
+    /src/cortex/serve/requirements.txt \
+    onnxruntime==1.2.0
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \

--- a/images/onnx-predictor-cpu/Dockerfile
+++ b/images/onnx-predictor-cpu/Dockerfile
@@ -33,14 +33,10 @@ RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip 
     echo "source ~/.env" >> ~/.bashrc
 
 ENV BASH_ENV=~/.env
+SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-
-# use /bin/bash to run in conda environment
-RUN /bin/bash -c \
-    "pip install --no-cache-dir \
-        -r /src/cortex/serve/requirements.txt \
-        onnxruntime==1.2.0"
+RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt onnxruntime==1.2.0
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \

--- a/images/onnx-predictor-gpu/Dockerfile
+++ b/images/onnx-predictor-gpu/Dockerfile
@@ -36,7 +36,9 @@ ENV BASH_ENV=~/.env
 SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt onnxruntime-gpu==1.2.0
+RUN pip install --no-cache-dir -r \
+    /src/cortex/serve/requirements.txt \
+    onnxruntime-gpu==1.2.0
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \

--- a/images/onnx-predictor-gpu/Dockerfile
+++ b/images/onnx-predictor-gpu/Dockerfile
@@ -33,14 +33,10 @@ RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip 
     echo "source ~/.env" >> ~/.bashrc
 
 ENV BASH_ENV=~/.env
+SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-
-# use /bin/bash to run in conda environment
-RUN /bin/bash -c \
-    "pip install --no-cache-dir \
-        -r /src/cortex/serve/requirements.txt \
-        onnxruntime-gpu==1.2.0"
+RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt onnxruntime-gpu==1.2.0
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \

--- a/images/python-predictor-cpu/Dockerfile
+++ b/images/python-predictor-cpu/Dockerfile
@@ -33,13 +33,10 @@ RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip 
     echo "source ~/.env" >> ~/.bashrc
 
 ENV BASH_ENV=~/.env
+SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-
-# use /bin/bash to run in conda environment
-RUN /bin/bash -c \
-    "pip install --no-cache-dir \
-        -r /src/cortex/serve/requirements.txt"
+RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \
@@ -53,28 +50,27 @@ RUN test "${SLIM}" = "true" || ( \
             libpng-dev \
             libsndfile1 \
         && apt-get clean -qq && rm -rf /var/lib/apt/lists/* \
-        && /bin/bash -c \
-            "pip install --no-cache-dir \
-                cloudpickle==1.4.1 \
-                Cython==0.29.17 \
-                joblib==0.14.1 \
-                Keras==2.3.1 \
-                nltk==3.5 \
-                np-utils==0.5.12.1 \
-                opencv-python==4.2.0.34 \
-                pandas==1.0.3 \
-                Pillow==7.1.2 \
-                scikit-image==0.17.1 \
-                scikit-learn==0.22.2.post1 \
-                scipy==1.4.1 \
-                six==1.14.0 \
-                statsmodels==0.11.1 \
-                sympy==1.5.1 \
-                tensorflow-cpu==2.1.0 \
-                tensorflow-hub==0.8.0 \
-                https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp36-cp36m-linux_x86_64.whl \
-                https://download.pytorch.org/whl/cpu/torchvision-0.6.0%2Bcpu-cp36-cp36m-linux_x86_64.whl \
-                xgboost==1.0.2" \
+        && pip install --no-cache-dir \
+            cloudpickle==1.4.1 \
+            Cython==0.29.17 \
+            joblib==0.14.1 \
+            Keras==2.3.1 \
+            nltk==3.5 \
+            np-utils==0.5.12.1 \
+            opencv-python==4.2.0.34 \
+            pandas==1.0.3 \
+            Pillow==7.1.2 \
+            scikit-image==0.17.1 \
+            scikit-learn==0.22.2.post1 \
+            scipy==1.4.1 \
+            six==1.14.0 \
+            statsmodels==0.11.1 \
+            sympy==1.5.1 \
+            tensorflow-cpu==2.1.0 \
+            tensorflow-hub==0.8.0 \
+            https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp36-cp36m-linux_x86_64.whl \
+            https://download.pytorch.org/whl/cpu/torchvision-0.6.0%2Bcpu-cp36-cp36m-linux_x86_64.whl \
+            xgboost==1.0.2 \
     )
 
 COPY pkg/workloads/cortex/consts.py /src/cortex

--- a/images/python-predictor-cpu/Dockerfile
+++ b/images/python-predictor-cpu/Dockerfile
@@ -36,7 +36,8 @@ ENV BASH_ENV=~/.env
 SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt
+RUN pip install --no-cache-dir -r \
+    /src/cortex/serve/requirements.txt
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \

--- a/images/python-predictor-gpu/Dockerfile
+++ b/images/python-predictor-gpu/Dockerfile
@@ -36,7 +36,8 @@ ENV BASH_ENV=~/.env
 SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt
+RUN pip install --no-cache-dir -r \
+    /src/cortex/serve/requirements.txt
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \

--- a/images/python-predictor-gpu/Dockerfile
+++ b/images/python-predictor-gpu/Dockerfile
@@ -33,12 +33,10 @@ RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip 
     echo "source ~/.env" >> ~/.bashrc
 
 ENV BASH_ENV=~/.env
+SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-
-RUN /bin/bash -c \
-    "pip install --no-cache-dir \
-        -r /src/cortex/serve/requirements.txt"
+RUN pip install --no-cache-dir -r /src/cortex/serve/requirements.txt
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \
@@ -55,28 +53,27 @@ RUN test "${SLIM}" = "true" || ( \
             libnvinfer6=6.0.1-1+cuda10.1 \
             libnvinfer-plugin6=6.0.1-1+cuda10.1 \
         && apt-get clean -qq && rm -rf /var/lib/apt/lists/* \
-        && /bin/bash -c \
-            "pip install --no-cache-dir \
-                cloudpickle==1.4.1 \
-                Cython==0.29.17 \
-                joblib==0.14.1 \
-                Keras==2.3.1 \
-                nltk==3.5 \
-                np-utils==0.5.12.1 \
-                opencv-python==4.2.0.34 \
-                pandas==1.0.3 \
-                Pillow==7.1.2 \
-                scikit-image==0.17.1 \
-                scikit-learn==0.22.2.post1 \
-                scipy==1.4.1 \
-                six==1.14.0 \
-                statsmodels==0.11.1 \
-                sympy==1.5.1 \
-                tensorflow-gpu==2.1.0 \
-                tensorflow-hub==0.8.0 \
-                https://download.pytorch.org/whl/cu101/torch-1.5.0%2Bcu101-cp36-cp36m-linux_x86_64.whl \
-                https://download.pytorch.org/whl/cu101/torchvision-0.6.0%2Bcu101-cp36-cp36m-linux_x86_64.whl \
-                xgboost==1.0.2" \
+        && pip install --no-cache-dir \
+            cloudpickle==1.4.1 \
+            Cython==0.29.17 \
+            joblib==0.14.1 \
+            Keras==2.3.1 \
+            nltk==3.5 \
+            np-utils==0.5.12.1 \
+            opencv-python==4.2.0.34 \
+            pandas==1.0.3 \
+            Pillow==7.1.2 \
+            scikit-image==0.17.1 \
+            scikit-learn==0.22.2.post1 \
+            scipy==1.4.1 \
+            six==1.14.0 \
+            statsmodels==0.11.1 \
+            sympy==1.5.1 \
+            tensorflow-gpu==2.1.0 \
+            tensorflow-hub==0.8.0 \
+            https://download.pytorch.org/whl/cu101/torch-1.5.0%2Bcu101-cp36-cp36m-linux_x86_64.whl \
+            https://download.pytorch.org/whl/cu101/torchvision-0.6.0%2Bcu101-cp36-cp36m-linux_x86_64.whl \
+            xgboost==1.0.2 \
     )
 
 COPY pkg/workloads/cortex/consts.py /src/cortex

--- a/images/tensorflow-predictor/Dockerfile
+++ b/images/tensorflow-predictor/Dockerfile
@@ -33,15 +33,12 @@ RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip 
     echo "source ~/.env" >> ~/.bashrc
 
 ENV BASH_ENV=~/.env
+SHELL ["/bin/bash", "-c"]
 
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
-
-# use /bin/bash to run in conda environment
-RUN /bin/bash -c \
-    "pip install --no-cache-dir \
-        -r /src/cortex/serve/requirements.txt \
-        tensorflow-cpu==2.1.0 \
-        tensorflow-serving-api==2.1.0"
+RUN pip install --no-cache-dir -r \
+    /src/cortex/serve/requirements.txt \
+    tensorflow-cpu==2.1.0 tensorflow-serving-api==2.1.0
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \
@@ -55,10 +52,9 @@ RUN test "${SLIM}" = "true" || ( \
             libpng-dev \
             libsndfile1 \
         && apt-get clean -qq && rm -rf /var/lib/apt/lists/* \
-        && /bin/bash -c \
-            "pip install --no-cache-dir \
-                opencv-python==4.2.0.34 \
-                tensorflow-hub==0.8.0" \
+        && pip install --no-cache-dir \
+            opencv-python==4.2.0.34 \
+            tensorflow-hub==0.8.0 \
     )
 
 COPY pkg/workloads/cortex/consts.py /src/cortex/

--- a/images/tensorflow-predictor/Dockerfile
+++ b/images/tensorflow-predictor/Dockerfile
@@ -38,7 +38,8 @@ SHELL ["/bin/bash", "-c"]
 COPY pkg/workloads/cortex/serve/requirements.txt /src/cortex/serve/requirements.txt
 RUN pip install --no-cache-dir -r \
     /src/cortex/serve/requirements.txt \
-    tensorflow-cpu==2.1.0 tensorflow-serving-api==2.1.0
+    tensorflow-cpu==2.1.0 \
+    tensorflow-serving-api==2.1.0
 
 ARG SLIM="false"
 RUN test "${SLIM}" = "true" || ( \


### PR DESCRIPTION
Coming as an improvement to https://github.com/cortexlabs/cortex/issues/1086#issuecomment-635913877. Closes https://github.com/cortexlabs/cortex/issues/1086.

Instead of having to run `RUN /bin/bash -c "pip install ..."` for a custom image based on any of Cortex's base serving images or inside `dependencies.sh`, the user now only has to add `RUN pip install ...`.

Also, clarify the docs about pip/conda installations for extended Dockerfiles.

---

checklist:

- [x] run `make test` and `make lint`
- [x] manually test Python/TensorFlow/ONNX deployments.
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
