### PR TITLE
Prevent GPU over provisioning during scale up

### DIFF
--- a/manager/generate_eks.py
+++ b/manager/generate_eks.py
@@ -102,8 +102,12 @@ def apply_gpu_settings(nodegroup):
         "tags": {
             "k8s.io/cluster-autoscaler/node-template/label/nvidia.com/gpu": "true",
             "k8s.io/cluster-autoscaler/node-template/taint/dedicated": "nvidia.com/gpu=true",
+            "k8s.io/cluster-autoscaler/node-template/label/k8s.amazonaws.com/accelerator": "true",  # accepted values are GPU type such as nvidia-tesla-k80 but using "true" as a placeholder for now because the value doesn't matter for AWS cluster autoscaler
         },
-        "labels": {"nvidia.com/gpu": "true"},
+        "labels": {
+            "nvidia.com/gpu": "true",
+            "k8s.amazonaws.com/accelerator": "true",  # accepted values are GPU type such as nvidia-tesla-k80 but using "true" as a placeholder for now because the value doesn't matter for AWS cluster autoscaler
+        },
         "taints": {"nvidia.com/gpu": "true:NoSchedule"},
     }
 


### PR DESCRIPTION
closes #1085 

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
