### PR TITLE
Fix cortex refresh typo in message

### DIFF
--- a/cli/cmd/refresh.go
+++ b/cli/cmd/refresh.go
@@ -38,7 +38,7 @@ func refreshInit() {
 
 var _refreshCmd = &cobra.Command{
 	Use:   "refresh API_NAME",
-	Short: "restart all replicas for an api (witout downtime)",
+	Short: "restart all replicas for an api (without downtime)",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		env, err := ReadOrConfigureEnv(_flagRefreshEnv)

--- a/docs/miscellaneous/cli.md
+++ b/docs/miscellaneous/cli.md
@@ -47,7 +47,7 @@ Flags:
 ## refresh
 
 ```text
-restart all replicas for an api (witout downtime)
+restart all replicas for an api (without downtime)
 
 Usage:
   cortex refresh API_NAME [flags]


### PR DESCRIPTION
Fix typo in message for `cortex refresh` API command.

---

checklist:

- [x] run `make test` and `make lint`
