### PR TITLE
Add support for local Docker images

### DIFF
--- a/cli/local/validations.go
+++ b/cli/local/validations.go
@@ -168,9 +168,7 @@ func ValidateLocalAPIs(apis []userconfig.API, projectFiles ProjectFiles, awsClie
 
 		pulledThisImage, err := docker.PullImage(image, dockerAuth, docker.PrintDots)
 		if err != nil {
-			if err := docker.CheckLocalImageAccessible(dockerClient, image); err != nil {
-				return errors.Wrap(err, "failed to pull image", image)
-			}
+			return errors.Wrap(err, "failed to pull image", image)
 		}
 
 		if pulledThisImage {

--- a/cli/local/validations.go
+++ b/cli/local/validations.go
@@ -168,7 +168,9 @@ func ValidateLocalAPIs(apis []userconfig.API, projectFiles ProjectFiles, awsClie
 
 		pulledThisImage, err := docker.PullImage(image, dockerAuth, docker.PrintDots)
 		if err != nil {
-			return errors.Wrap(err, "failed to pull image", image)
+			if err := docker.CheckLocalImageAccessible(dockerClient, image); err != nil {
+				return errors.Wrap(err, "failed to pull image", image)
+			}
 		}
 
 		if pulledThisImage {

--- a/pkg/lib/configreader/validators.go
+++ b/pkg/lib/configreader/validators.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cortexlabs/cortex/pkg/lib/aws"
+	"github.com/cortexlabs/cortex/pkg/lib/docker"
 	"github.com/cortexlabs/cortex/pkg/lib/files"
 	"github.com/cortexlabs/cortex/pkg/lib/urls"
 )
@@ -155,12 +156,7 @@ func ValidateImageVersion(image, cortexVersion string) (string, error) {
 		return image, nil
 	}
 
-	var tag string
-
-	if colonIndex := strings.LastIndex(image, ":"); colonIndex != -1 {
-		tag = image[colonIndex+1:]
-	}
-
+	tag := docker.ExtractImageTag(image)
 	// in docker, missing tag implies "latest"
 	if tag == "" {
 		tag = "latest"

--- a/pkg/lib/docker/docker.go
+++ b/pkg/lib/docker/docker.go
@@ -143,8 +143,8 @@ func PullImage(image string, encodedAuthConfig string, pullVerbosity PullVerbosi
 		return false, err
 	}
 
-	if err := CheckLocalImageAccessible(dockerClient, image); err != nil {
-		return false, err
+	if err := CheckLocalImageAccessible(dockerClient, image); err == nil {
+		return false, nil
 	}
 
 	pullOutput, err := dockerClient.ImagePull(context.Background(), image, dockertypes.ImagePullOptions{

--- a/pkg/lib/docker/docker.go
+++ b/pkg/lib/docker/docker.go
@@ -143,17 +143,8 @@ func PullImage(image string, encodedAuthConfig string, pullVerbosity PullVerbosi
 		return false, err
 	}
 
-	existingImages, err := dockerClient.ImageList(context.Background(), dockertypes.ImageListOptions{})
-	if err != nil {
-		return false, WrapDockerError(err)
-	}
-
-	for _, existingImage := range existingImages {
-		for _, tag := range existingImage.RepoTags {
-			if tag == image {
-				return false, nil
-			}
-		}
+	if err := CheckLocalImageAccessible(dockerClient, image); err != nil {
+		return false, err
 	}
 
 	pullOutput, err := dockerClient.ImagePull(context.Background(), image, dockertypes.ImagePullOptions{

--- a/pkg/lib/docker/errors.go
+++ b/pkg/lib/docker/errors.go
@@ -57,15 +57,11 @@ func ErrorDockerPermissions(err error) error {
 }
 
 func ErrorImageInaccessible(image string, cause error) error {
-	dockerErrMsg := ""
+	message := fmt.Sprintf("%s is not accessible", image)
 	if cause != nil {
-		dockerErrMsg = errors.Message(cause)
+		message += "\n" + errors.Message(cause) // add \n because docker client errors are
 	}
 
-	message := fmt.Sprintf("%s is not accessible", image)
-	if len(dockerErrMsg) > 0 {
-		message = fmt.Sprintf("%s\n%s", message, dockerErrMsg) // add \n because docker client errors are verbose
-	}
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrImageInaccessible,
 		Message: message,

--- a/pkg/lib/docker/errors.go
+++ b/pkg/lib/docker/errors.go
@@ -57,10 +57,18 @@ func ErrorDockerPermissions(err error) error {
 }
 
 func ErrorImageInaccessible(image string, cause error) error {
-	dockerErrMsg := errors.Message(cause)
+	dockerErrMsg := ""
+	if cause != nil {
+		dockerErrMsg = errors.Message(cause)
+	}
+
+	message := fmt.Sprintf("%s is not accessible", image)
+	if len(dockerErrMsg) > 0 {
+		message = fmt.Sprintf("%s\n%s", message, dockerErrMsg) // add \n because docker client errors are verbose
+	}
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrImageInaccessible,
-		Message: fmt.Sprintf("%s is not accessible\n%s", image, dockerErrMsg), // add \n because docker client errors are verbose
+		Message: message,
 		Cause:   cause,
 	})
 }

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -471,7 +471,7 @@ func validatePredictor(predictor *userconfig.Predictor, projectFiles ProjectFile
 		if err := validateTensorFlowPredictor(predictor, providerType, projectFiles, awsClient); err != nil {
 			return err
 		}
-		if err := validateDockerImagePath(predictor.TensorFlowServingImage, awsClient); err != nil {
+		if err := validateDockerImagePath(predictor.TensorFlowServingImage, providerType, awsClient); err != nil {
 			return errors.Wrap(err, userconfig.TensorFlowServingImageKey)
 		}
 	case userconfig.ONNXPredictorType:
@@ -480,7 +480,7 @@ func validatePredictor(predictor *userconfig.Predictor, projectFiles ProjectFile
 		}
 	}
 
-	if err := validateDockerImagePath(predictor.Image, awsClient); err != nil {
+	if err := validateDockerImagePath(predictor.Image, providerType, awsClient); err != nil {
 		return errors.Wrap(err, userconfig.ImageKey)
 	}
 
@@ -828,7 +828,7 @@ func FindDuplicateNames(apis []userconfig.API) []userconfig.API {
 	return nil
 }
 
-func validateDockerImagePath(image string, awsClient *aws.Client) error {
+func validateDockerImagePath(image string, providerType types.ProviderType, awsClient *aws.Client) error {
 	if consts.DefaultImagePathsSet.Has(image) {
 		return nil
 	}

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -836,6 +836,17 @@ func validateDockerImagePath(image string, providerType types.ProviderType, awsC
 		return err
 	}
 
+	dockerClient, err := docker.GetDockerClient()
+	if err != nil {
+		return err
+	}
+
+	if providerType == types.LocalProviderType {
+		if err := docker.CheckLocalImageAccessible(dockerClient, image); err == nil {
+			return nil
+		}
+	}
+
 	dockerAuth := docker.NoAuth
 	if regex.IsValidECRURL(image) {
 		if awsClient.IsAnonymous {
@@ -871,17 +882,7 @@ func validateDockerImagePath(image string, providerType types.ProviderType, awsC
 		}
 	}
 
-	dockerClient, err := docker.GetDockerClient()
-	if err != nil {
-		return err
-	}
-
 	if err := docker.CheckImageAccessible(dockerClient, image, dockerAuth); err != nil {
-		if providerType == types.LocalProviderType {
-			if err := docker.CheckLocalImageAccessible(dockerClient, image); err == nil {
-				return nil
-			}
-		}
 		return err
 	}
 

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -842,6 +842,7 @@ func validateDockerImagePath(image string, providerType types.ProviderType, awsC
 	}
 
 	if providerType == types.LocalProviderType {
+		// short circuit if the image is already available locally
 		if err := docker.CheckLocalImageAccessible(dockerClient, image); err == nil {
 			return nil
 		}

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -877,7 +877,13 @@ func validateDockerImagePath(image string, providerType types.ProviderType, awsC
 	}
 
 	if err := docker.CheckImageAccessible(dockerClient, image, dockerAuth); err != nil {
+		if providerType == types.LocalProviderType {
+			if err := docker.CheckLocalImageAccessible(dockerClient, image); err == nil {
+				return nil
+			}
+		}
 		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
Closes #1094.

When validating for the local provider, Cortex first checks if the Docker serving image is available locally and if it isn't, then it checks if it's on DockerHub or on AWS ECR and if it can't find there either, then it will throw the docker client's error (like usual).

Next, before the container is launched, Cortex first tries to pull the image and if it isn't available, then it checks if there's a matching local image and if that too fails, it returns an error message of this sort: _"failed to pull image"_.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
