### PR TITLE
Remove local port from API ID calculation

### DIFF
--- a/cli/local/api.go
+++ b/cli/local/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/files"
 	"github.com/cortexlabs/cortex/pkg/lib/msgpack"
+	"github.com/cortexlabs/cortex/pkg/lib/pointer"
 	"github.com/cortexlabs/cortex/pkg/lib/sets/strset"
 	"github.com/cortexlabs/cortex/pkg/types/spec"
 	"github.com/cortexlabs/cortex/pkg/types/userconfig"
@@ -113,10 +114,25 @@ func writeAPISpec(apiSpec *spec.API) error {
 }
 
 func areAPIsEqual(a1, a2 *spec.API) bool {
-	if a1 != nil && a2 != nil {
-		return strset.FromSlice(a1.ModelIDs()).IsEqual(strset.FromSlice(a2.ModelIDs())) && a1.ID == a2.ID && a1.Compute.Equals(a2.Compute)
+	if a1 == nil && a2 == nil {
+		return true
 	}
-	return a1 == nil && a2 == nil
+	if a1 == nil || a2 == nil {
+		return false
+	}
+	if a1.ID != a2.ID {
+		return false
+	}
+	if !pointer.AreIntsEqual(a1.Networking.LocalPort, a2.Networking.LocalPort) {
+		return false
+	}
+	if !a1.Compute.Equals(a2.Compute) {
+		return false
+	}
+	if !strset.FromSlice(a1.ModelIDs()).IsEqual(strset.FromSlice(a2.ModelIDs())) {
+		return false
+	}
+	return true
 }
 
 func DeleteAPI(apiName string) error {

--- a/pkg/lib/pointer/equal.go
+++ b/pkg/lib/pointer/equal.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 Cortex Labs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pointer
+
+import (
+	"time"
+)
+
+func AreIntsEqual(v1 *int, v2 *int) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreInt8sEqual(v1 *int8, v2 *int8) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreInt16sEqual(v1 *int16, v2 *int16) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreInt32sEqual(v1 *int32, v2 *int32) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreInt64sEqual(v1 *int64, v2 *int64) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreFloat64sEqual(v1 *float64, v2 *float64) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreFloat32sEqual(v1 *float32, v2 *float32) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreStringsEqual(v1 *string, v2 *string) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreBoolsEqual(v1 *bool, v2 *bool) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}
+
+func AreTimesEqual(v1 *time.Time, v2 *time.Time) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return v1.Equal(*v2)
+}
+
+func AreDurationsEqual(v1 *time.Duration, v2 *time.Duration) bool {
+	if v1 == nil && v2 == nil {
+		return true
+	}
+	if v1 == nil || v2 == nil {
+		return false
+	}
+	return *v1 == *v2
+}

--- a/pkg/types/spec/api.go
+++ b/pkg/types/spec/api.go
@@ -50,9 +50,6 @@ type LocalModelCache struct {
 func GetAPISpec(apiConfig *userconfig.API, projectID string, deploymentID string) *API {
 	var buf bytes.Buffer
 	buf.WriteString(apiConfig.Name)
-	if apiConfig.Networking.LocalPort != nil {
-		buf.WriteString(s.Obj(*apiConfig.Networking.LocalPort))
-	}
 	buf.WriteString(s.Obj(apiConfig.Predictor))
 	buf.WriteString(s.Obj(apiConfig.Monitoring))
 	buf.WriteString(deploymentID)


### PR DESCRIPTION
I think we should revisit API IDs soon, but for now, it seemed to me that local port should be removed from it. For now, I am thinking that the "API ID" should be used mostly as the "predictor ID". We should make guidelines around this, and improve the naming, but for now I think this makes sense; what do you think?