### PR TITLE
Display image pull error

### DIFF
--- a/docs/deployments/statuses.md
+++ b/docs/deployments/statuses.md
@@ -7,5 +7,6 @@ _WARNING: you are on the master branch, please refer to the docs on the branch t
 | live                  | API is deployed and ready to serve prediction requests (at least one replica is running) |
 | updating              | API is updating |
 | error                 | API was not created due to an error; run `cortex logs <name>` to view the logs |
+| error (image pull)    | API was not created because one of the specified Docker images was inaccessible at runtime; check that your API's docker images exist and are accessible via your cluster operator's AWS credentials |
 | error (out of memory) | API was terminated due to excessive memory usage; try allocating more memory to the API and re-deploying |
 | compute unavailable   | API could not start due to insufficient memory, CPU, GPU or Inf in the cluster; some replicas may be ready |

--- a/pkg/operator/operator/status.go
+++ b/pkg/operator/operator/status.go
@@ -147,6 +147,8 @@ func addPodToReplicaCounts(pod *kcore.Pod, deployment *kapps.Deployment, counts 
 		subCounts.Initializing++
 	case k8s.PodStatusRunning:
 		subCounts.Initializing++
+	case k8s.PodStatusErrImagePull:
+		subCounts.ErrImagePull++
 	case k8s.PodStatusTerminating:
 		subCounts.Terminating++
 	case k8s.PodStatusFailed:
@@ -163,6 +165,10 @@ func addPodToReplicaCounts(pod *kcore.Pod, deployment *kapps.Deployment, counts 
 func getStatusCode(counts *status.ReplicaCounts, minReplicas int32) status.Code {
 	if counts.Updated.Ready >= counts.Requested {
 		return status.Live
+	}
+
+	if counts.Updated.ErrImagePull > 0 {
+		return status.ErrorImagePull
 	}
 
 	if counts.Updated.Failed > 0 || counts.Updated.Killed > 0 {

--- a/pkg/types/status/code.go
+++ b/pkg/types/status/code.go
@@ -22,6 +22,7 @@ const (
 	Unknown Code = iota
 	Stalled
 	Error
+	ErrorImagePull
 	OOM
 	Live
 	Updating
@@ -31,6 +32,7 @@ var _codes = []string{
 	"status_unknown",
 	"status_stalled",
 	"status_error",
+	"status_error_image_pull",
 	"status_oom",
 	"status_live",
 	"status_updating",
@@ -42,6 +44,7 @@ var _codeMessages = []string{
 	"unknown",               // Unknown
 	"compute unavailable",   // Stalled
 	"error",                 // Error
+	"error (image pull)",    // Live
 	"error (out of memory)", // OOM
 	"live",                  // Live
 	"updating",              // Updating

--- a/pkg/types/status/status.go
+++ b/pkg/types/status/status.go
@@ -47,5 +47,5 @@ func (status *Status) Message() string {
 }
 
 func (src *SubReplicaCounts) TotalFailed() int32 {
-	return src.Failed + src.Killed + src.KilledOOM + src.Stalled
+	return src.Failed + src.ErrImagePull + src.Killed + src.KilledOOM + src.Stalled
 }

--- a/pkg/types/status/status.go
+++ b/pkg/types/status/status.go
@@ -33,6 +33,7 @@ type SubReplicaCounts struct {
 	Pending      int32 `json:"pending"`
 	Initializing int32 `json:"initializing"`
 	Ready        int32 `json:"ready"`
+	ErrImagePull int32 `json:"err_image_pull"`
 	Terminating  int32 `json:"terminating"`
 	Failed       int32 `json:"failed"`
 	Killed       int32 `json:"killed"`


### PR DESCRIPTION
closes #955

Note: ideally this error should not be reached, since the operator now validates access to Docker images before deploying an API.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
