### PR TITLE
Use info log level when TF model is still being loaded

### DIFF
--- a/pkg/workloads/cortex/lib/server/tensorflow.py
+++ b/pkg/workloads/cortex/lib/server/tensorflow.py
@@ -56,7 +56,7 @@ class TensorFlowServing:
         def log_loading_models():
             while not loaded_models.is_set():
                 time.sleep(2)
-                cx_logger().warn("model(s) still loading ...")
+                cx_logger().info("model(s) still loading ...")
 
         log_thread = threading.Thread(target=log_loading_models, daemon=True)
         log_thread.start()


### PR DESCRIPTION
Change the log level for the log message that repeatedly gets printed when a model is still being loaded with the `TensorFlowPredictor` predictor type:

`2020-06-26 22:20:52.578425:cortex:pid-28:WARNING:model(s) still loading ...` -> 
-> `2020-06-26 22:20:52.578425:cortex:pid-28:INFO:model(s) still loading ...`

`WARNING` suggests that something bad has happened and it's retrying to heal itself, whereas in our case, it's not trying to do that - it just means it's still loading and if it does fail, then it will throw a meaningful error.

---

checklist:

- [x] run `make test` and `make lint`
