### PR TITLE
Move cortex verification from serve.py to run.sh

### DIFF
--- a/pkg/workloads/cortex/consts.py
+++ b/pkg/workloads/cortex/consts.py
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORTEX_VERSION = "master"
 SINGLE_MODEL_NAME = "_cortex_default"
 INFERENTIA_NEURON_SOCKET = "/sock/neuron.sock"

--- a/pkg/workloads/cortex/serve/run.sh
+++ b/pkg/workloads/cortex/serve/run.sh
@@ -67,7 +67,7 @@ if [ -f "/mnt/project/conda-packages.txt" ]; then
 fi
 
 # CORTEX_VERSION x1
-export EXPECTED_CORTEX_VERSION=0.18.0
+export EXPECTED_CORTEX_VERSION=master
 
 if [ "$CORTEX_VERSION" != "$EXPECTED_CORTEX_VERSION" ]; then
     if [ "$CORTEX_PROVIDER" == "local" ]; then

--- a/pkg/workloads/cortex/serve/run.sh
+++ b/pkg/workloads/cortex/serve/run.sh
@@ -66,6 +66,18 @@ if [ -f "/mnt/project/conda-packages.txt" ]; then
     fi
 fi
 
+# CORTEX_VERSION x1
+export EXPECTED_CORTEX_VERSION=0.18.0
+
+if [ "$CORTEX_VERSION" != "$EXPECTED_CORTEX_VERSION" ]; then
+    if [ "$CORTEX_PROVIDER" == "local" ]; then
+        echo "your Cortex CLI version ($CORTEX_VERSION) doesn't match your predictor image version ($EXPECTED_CORTEX_VERSION); please update your predictor image by modifying the \`image\` field in your API configuration file (e.g. cortex.yaml) and re-running \`cortex deploy\`, or update your CLI by following the instructions at https://docs.cortex.dev/cluster-management/update#upgrading-to-a-newer-version-of-cortex"
+    else
+        echo "your Cortex operator version ($CORTEX_VERSION) doesn't match your predictor image version ($EXPECTED_CORTEX_VERSION); please update your predictor image by modifying the \`image\` field in your API configuration file (e.g. cortex.yaml) and re-running \`cortex deploy\`, or update your cluster by following the instructions at https://docs.cortex.dev/cluster-management/update#upgrading-to-a-newer-version-of-cortex"
+    fi
+    exit 1
+fi
+
 # install pip packages
 if [ -f "/mnt/project/requirements.txt" ]; then
     pip --no-cache-dir install -r /mnt/project/requirements.txt

--- a/pkg/workloads/cortex/serve/serve.py
+++ b/pkg/workloads/cortex/serve/serve.py
@@ -32,17 +32,11 @@ from starlette.responses import Response
 from starlette.background import BackgroundTasks
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from cortex import consts
 from cortex.lib import util
 from cortex.lib.type import API, get_spec
 from cortex.lib.log import cx_logger
 from cortex.lib.storage import S3, LocalStorage, FileLock
 from cortex.lib.exceptions import UserRuntimeException
-
-if os.environ["CORTEX_VERSION"] != consts.CORTEX_VERSION:
-    errMsg = f"your Cortex operator version ({os.environ['CORTEX_VERSION']}) doesn't match your predictor image version ({consts.CORTEX_VERSION}); please update your predictor image by modifying the `image` field in your API configuration file (e.g. cortex.yaml) and re-running `cortex deploy`, or update your cluster by following the instructions at https://docs.cortex.dev/cluster-management/update"
-    raise ValueError(errMsg)
-
 
 API_SUMMARY_MESSAGE = (
     "make a prediction by sending a post request to this endpoint with a json payload"
@@ -285,7 +279,7 @@ def start_fn():
             **raw_api_spec,
         )
         client = api.predictor.initialize_client(
-            tf_serving_host=tf_serving_host, tf_serving_port=tf_serving_port,
+            tf_serving_host=tf_serving_host, tf_serving_port=tf_serving_port
         )
         cx_logger().info("loading the predictor from {}".format(api.predictor.path))
         predictor_impl = api.predictor.initialize_impl(project_dir, client)


### PR DESCRIPTION
Catch image version mismatch earlier so to make errors such as https://github.com/cortexlabs/cortex/issues/1178 easier to debug for users who've created custom images.

Since start_uvicorn.py has quite a bit of application code, the image version verification should happen before start_uvicorn.py is run.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ ] update examples
- [ ] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
- [ ] cherry-pick into release branches if applicable
- [ ] alert the dev team if the dev environment changed
