### PR TITLE
Remove unnecessary env var & reposition env var source

### DIFF
--- a/cli/local/docker_spec.go
+++ b/cli/local/docker_spec.go
@@ -93,7 +93,7 @@ func getAPIEnv(api *spec.API, awsClient *aws.Client) []string {
 		"CORTEX_THREADS_PER_PROCESS="+s.Int32(api.Predictor.ThreadsPerProcess),
 		// add 1 because it was required to achieve the target concurrency for 1 process, 1 thread
 		"CORTEX_MAX_PROCESS_CONCURRENCY="+s.Int64(1+int64(math.Round(float64(consts.DefaultMaxReplicaConcurrency)/float64(api.Predictor.ProcessesPerReplica)))),
-		"CORTEX_SO_MAX_CONN=1000",
+		"CORTEX_SO_MAX_CONN="+s.Int64(consts.DefaultMaxReplicaConcurrency+100),
 		"AWS_REGION="+awsClient.Region,
 	)
 

--- a/cli/local/docker_spec.go
+++ b/cli/local/docker_spec.go
@@ -93,7 +93,7 @@ func getAPIEnv(api *spec.API, awsClient *aws.Client) []string {
 		"CORTEX_THREADS_PER_PROCESS="+s.Int32(api.Predictor.ThreadsPerProcess),
 		// add 1 because it was required to achieve the target concurrency for 1 process, 1 thread
 		"CORTEX_MAX_PROCESS_CONCURRENCY="+s.Int64(1+int64(math.Round(float64(consts.DefaultMaxReplicaConcurrency)/float64(api.Predictor.ProcessesPerReplica)))),
-		"CORTEX_SO_MAX_CONN="+s.Int64(consts.DefaultMaxReplicaConcurrency+100),
+		"CORTEX_SO_MAX_CONN="+s.Int64(consts.DefaultMaxReplicaConcurrency+100), // add a buffer to be safe
 		"AWS_REGION="+awsClient.Region,
 	)
 

--- a/pkg/operator/resources/syncapi/k8s_specs.go
+++ b/pkg/operator/resources/syncapi/k8s_specs.go
@@ -638,10 +638,6 @@ func getEnvVars(api *spec.API, container string) []kcore.EnvVar {
 				Value: s.Int32(api.Predictor.ThreadsPerProcess),
 			},
 			kcore.EnvVar{
-				Name:  "CORTEX_MAX_REPLICA_CONCURRENCY",
-				Value: s.Int64(api.Autoscaling.MaxReplicaConcurrency),
-			},
-			kcore.EnvVar{
 				Name: "CORTEX_MAX_PROCESS_CONCURRENCY",
 				// add 1 because it was required to achieve the target concurrency for 1 process, 1 thread
 				Value: s.Int64(1 + int64(math.Round(float64(api.Autoscaling.MaxReplicaConcurrency)/float64(api.Predictor.ProcessesPerReplica)))),

--- a/pkg/workloads/cortex/serve/run.sh
+++ b/pkg/workloads/cortex/serve/run.sh
@@ -39,6 +39,13 @@ rm -rf /mnt/workspace/api_readiness.txt
 # allow for the liveness check to pass until the API is running
 echo "9999999999" > /mnt/workspace/api_liveness.txt
 
+# export environment variables
+if [ -f "/mnt/project/.env" ]; then
+    set -a
+    source /mnt/project/.env
+    set +a
+fi
+
 export PYTHONPATH=$PYTHONPATH:$PYTHON_PATH
 # ensure predictor print() statements are always flushed
 export PYTHONUNBUFFERED=TRUE
@@ -47,13 +54,6 @@ if [ "$CORTEX_PROVIDER" != "local" ]; then
     sysctl -w net.core.somaxconn=$CORTEX_SO_MAX_CONN >/dev/null
     sysctl -w net.ipv4.ip_local_port_range="15000 64000" >/dev/null
     sysctl -w net.ipv4.tcp_fin_timeout=30 >/dev/null
-fi
-
-# export environment variables
-if [ -f "/mnt/project/.env" ]; then
-    set -a
-    source /mnt/project/.env
-    set +a
 fi
 
 # execute script if present in project's directory

--- a/pkg/workloads/cortex/serve/start_uvicorn.py
+++ b/pkg/workloads/cortex/serve/start_uvicorn.py
@@ -87,7 +87,9 @@ def main():
         host="0.0.0.0",
         port=int(os.environ["CORTEX_SERVING_PORT"]),
         workers=int(os.environ["CORTEX_PROCESSES_PER_REPLICA"]),
-        limit_concurrency=int(os.environ["CORTEX_MAX_PROCESS_CONCURRENCY"]),
+        limit_concurrency=int(
+            os.environ["CORTEX_MAX_PROCESS_CONCURRENCY"]
+        ),  # this is a per process limit
         backlog=int(os.environ["CORTEX_SO_MAX_CONN"]),
         log_config=log_config,
         log_level="info",


### PR DESCRIPTION
`CORTEX_MAX_REPLICA_CONCURRENCY` environment variable is no longer required and placing the sourcing of `.env` before any export in `run.sh` might give us more leeway when it comes to various workarounds for our users.

---

checklist:

- [x] run `make test` and `make lint`
