### PR TITLE
Fix dynamic axes for ONNX models

### DIFF
--- a/pkg/workloads/cortex/lib/client/onnx.py
+++ b/pkg/workloads/cortex/lib/client/onnx.py
@@ -112,7 +112,7 @@ def transform_to_numpy(input_pyobj, input_metadata, model_name):
     try:
         for idx, dim in enumerate(target_shape):
             # dynamic_axes implies that a given dimension can have any size
-            if type(dim) is str and "dynamic_axes" in dim:
+            if type(dim) is str:
                 target_shape[idx] = -1
             elif type(dim) is not int:
                 target_shape[idx] = 1

--- a/pkg/workloads/cortex/lib/client/onnx.py
+++ b/pkg/workloads/cortex/lib/client/onnx.py
@@ -111,7 +111,6 @@ def transform_to_numpy(input_pyobj, input_metadata, model_name):
 
     try:
         for idx, dim in enumerate(target_shape):
-            # dynamic_axes implies that a given dimension can have any size
             if type(dim) is str:
                 target_shape[idx] = -1
             elif type(dim) is not int:


### PR DESCRIPTION
Fixes #1186.

It appears that setting the input shape to a generic string should signify to the user that the shape is dynamic and can be of any size. Currently, the Cortex ONNX client only checks if `"dynamic_axes"` is a substring of the shape dimension's value (if it's a string). As it appears to me, that's only a convention and the string can be set to anything.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
