### PR TITLE
Fix POST response status codes

### DIFF
--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -404,7 +404,7 @@ The `payload` parameter type will be a `starlette.datastructures.FormData` objec
 # payload parameter is a starlette.datastructures.FormData object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: multipart/form" \
-    -d @file.txt
+    -F "fieldName=@file.txt"
 ```
 
 The `payload` parameter type will be a `starlette.datastructures.FormData` object if a request with a `Content-Type: application/x-www-form-urlencoded` is made:

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -74,8 +74,9 @@ class PythonPredictor:
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as from where to download the model and initialization files, or any configurable model parameters. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
-To see what values the `predict` method can return, check the [API responses](#api-responses) section.
+Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
+
+Your API can be configured to respond with different response payload types such as `JSON`-parseable, `string`, `bytes` objects, and more. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
 
 ### Examples
 
@@ -233,8 +234,9 @@ When multiple models are defined using the Predictor's `models` field, the `tens
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
-To see what values the `predict` method can return, check the [API responses](#api-responses) section.
+Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
+
+Your API can be configured to respond with different response payload types such as `JSON`-parseable, `string`, `bytes` objects, and more. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
 
 ### Examples
 
@@ -317,8 +319,9 @@ When multiple models are defined using the Predictor's `models` field, the `onnx
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
-To see what values the `predict` method can return, check the [API responses](#api-responses) section.
+Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
+
+Your API can be configured to respond with different response payload types such as `JSON`-parseable, `string`, `bytes` objects, and more. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
 
 ### Examples
 
@@ -373,10 +376,9 @@ The type of the `payload` parameter in `predict(self, payload)` can vary based o
 1. For `Content-Type: multipart/form` / `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)).
 1. For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.
 
-The `payload` parameter type will be a Python `dict` object if a request with a JSON payload is made:
+The `payload` parameter type will be a Python object (*lists*, *dicts*, *numbers*) if a request with a JSON payload is made:
 
 ```bash
-# payload parameter is a dictionary object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: application/json" \
     -d '{"key": "value"}'
@@ -385,7 +387,6 @@ $ curl http://***.amazonaws.com/my-api \
 The `payload` parameter type will be a `bytes` object if a request with a `Content-Type: application/octet-stream` is made:
 
 ```bash
-# payload parameter is a bytes object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: application/octet-stream" \
     -d @file.bin
@@ -394,7 +395,6 @@ $ curl http://***.amazonaws.com/my-api \
 The `payload` parameter type will be a `bytes` object if a request doesn't have the `Content-Type` set:
 
 ```bash
-# payload parameter is a bytes object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type:" \
     -d @sample.txt
@@ -403,7 +403,6 @@ $ curl http://***.amazonaws.com/my-api \
 The `payload` parameter type will be a `starlette.datastructures.FormData` object if a request with a `Content-Type: multipart/form` is made:
 
 ```bash
-# payload parameter is a starlette.datastructures.FormData object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: multipart/form" \
     -F "fieldName=@file.txt"
@@ -412,7 +411,6 @@ $ curl http://***.amazonaws.com/my-api \
 The `payload` parameter type will be a `starlette.datastructures.FormData` object if a request with a `Content-Type: application/x-www-form-urlencoded` is made:
 
 ```bash
-# payload parameter is a starlette.datastructures.FormData object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: application/x-www-form-urlencoded" \
     -d @file.txt
@@ -420,8 +418,7 @@ $ curl http://***.amazonaws.com/my-api \
 
 The `payload` parameter type will be a `starlette.datastructures.FormData` object if no headers are added to the request:
 
-```bash
-# payload parameter is a starlette.datastructures.FormData object
+```bashß
 $ curl http://***.amazonaws.com/my-api \
     -X POST \
     -d @file.txt

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -364,9 +364,14 @@ If your application requires additional dependencies, you can install additional
 
 ## API requests
 
-The `payload` parameter in the `predict(self, payload)` method can be of different types depending on the content type of the request.
+The type of the `payload` parameter in `predict(self, payload)` can vary based on the content type of the request.
 
-Here are some examples:
+The `payload` parameter is parsed according to the `Content-Type` header in the request:
+1. For `Content-Type: application/json`, `payload` will be the parsed JSON body.
+1. For `Content-Type: multipart/form` / `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData`.
+1. For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.
+
+The `payload` parameter type will be a Python `dict` object if a request with a JSON payload is made:
 
 ```bash
 # payload parameter is a dictionary object
@@ -375,12 +380,16 @@ $ curl http://***.amazonaws.com/my-api \
     -d '{"key": "value"}'
 ```
 
+The `payload` parameter type will be a `bytes` object if a request with a `Content-Type: application/octet-stream` is made:
+
 ```bash
 # payload parameter is a bytes object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: application/octet-stream" \
     -d @file.bin
 ```
+
+The `payload` parameter type will be a `bytes` object if a request doesn't have the `Content-Type` set:
 
 ```bash
 # payload parameter is a bytes object
@@ -389,6 +398,8 @@ $ curl http://***.amazonaws.com/my-api \
     -d @sample.txt
 ```
 
+The `payload` parameter type will be a `starlette.datastructures.FormData` object if a request with a `Content-Type: multipart/form` is made:
+
 ```bash
 # payload parameter is a starlette.datastructures.FormData object
 $ curl http://***.amazonaws.com/my-api \
@@ -396,12 +407,16 @@ $ curl http://***.amazonaws.com/my-api \
     -d @file.txt
 ```
 
+The `payload` parameter type will be a `starlette.datastructures.FormData` object if a request with a `Content-Type: application/x-www-form-urlencoded` is made:
+
 ```bash
 # payload parameter is a starlette.datastructures.FormData object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: application/x-www-form-urlencoded" \
     -d @file.txt
 ```
+
+The `payload` parameter type will be a `starlette.datastructures.FormData` object if no headers are added to the request:
 
 ```bash
 # payload parameter is a starlette.datastructures.FormData object

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -362,6 +362,40 @@ The pre-installed system packages are listed in [images/onnx-predictor-cpu/Docke
 
 If your application requires additional dependencies, you can install additional [Python packages](python-packages.md) and [system packages](system-packages.md).
 
+## API requests
+
+The `payload` parameter in the `predict(self, payload)` method can be of different types depending on the content type of the request.
+
+Here are some examples:
+
+```bash
+# payload parameter is a dictionary object
+$ curl http://***.amazonaws.com/my-api \
+    -X POST -H "Content-Type: application/json" \
+    -d '{"key": "value"}'
+```
+
+```bash
+# payload parameter is a bytes object
+$ curl http://***.amazonaws.com/my-api \
+    -X POST -H "Content-Type: application/octet-stream" \
+    -d @file.bin
+```
+
+```bash
+# payload parameter is a starlette.datastructures.FormData object
+$ curl http://***.amazonaws.com/my-api \
+    -X POST -H "Content-Type: multipart/form" \
+    -d @file.txt
+```
+
+```bash
+# payload parameter is a starlette.datastructures.FormData object
+$ curl http://***.amazonaws.com/my-api \
+    -X POST -H "Content-Type: application/x-www-form-urlencoded" \
+    -d @file.txt
+```
+
 ## API responses
 
 The response of your `predict()` function may be:

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -74,7 +74,7 @@ class PythonPredictor:
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as from where to download the model and initialization files, or any configurable model parameters. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-The `payload` parameter is parsed according to the `Content-Type` header in the request. For `Content-Type: application/json`, `payload` will be the parsed JSON body. For `Content-Type: multipart/form` or `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)). For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.
+To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
 
 ### Examples
 
@@ -232,7 +232,7 @@ When multiple models are defined using the Predictor's `models` field, the `tens
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-The `payload` parameter is parsed according to the `Content-Type` header in the request. For `Content-Type: application/json`, `payload` will be the parsed JSON body. For `Content-Type: multipart/form` or `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)). For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.
+To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
 
 ### Examples
 
@@ -315,7 +315,7 @@ When multiple models are defined using the Predictor's `models` field, the `onnx
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-The `payload` parameter is parsed according to the `Content-Type` header in the request. For `Content-Type: application/json`, `payload` will be the parsed JSON body. For `Content-Type: multipart/form` or `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)). For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.
+To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
 
 ### Examples
 
@@ -368,7 +368,7 @@ The type of the `payload` parameter in `predict(self, payload)` can vary based o
 
 The `payload` parameter is parsed according to the `Content-Type` header in the request:
 1. For `Content-Type: application/json`, `payload` will be the parsed JSON body.
-1. For `Content-Type: multipart/form` / `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData`.
+1. For `Content-Type: multipart/form` / `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)).
 1. For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.
 
 The `payload` parameter type will be a Python `dict` object if a request with a JSON payload is made:

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -74,9 +74,9 @@ class PythonPredictor:
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as from where to download the model and initialization files, or any configurable model parameters. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
+Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` method.
 
-Your API can be configured to respond with different types of payload such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
+Your `predictor` method can return different types of objects such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how to configure your `predictor` method to respond with different response codes and content-types.
 
 ### Examples
 
@@ -234,9 +234,9 @@ When multiple models are defined using the Predictor's `models` field, the `tens
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
+Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` method.
 
-Your API can be configured to respond with different types of payload such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
+Your `predictor` method can return different types of objects such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how to configure your `predictor` method to respond with different response codes and content-types.
 
 ### Examples
 
@@ -319,9 +319,9 @@ When multiple models are defined using the Predictor's `models` field, the `onnx
 
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
-Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
+Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` method.
 
-Your API can be configured to respond with different types of payload such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
+Your `predictor` method can return different types of objects such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how to configure your `predictor` method to respond with different response codes and content-types.
 
 ### Examples
 
@@ -373,7 +373,7 @@ If your application requires additional dependencies, you can install additional
 The type of the `payload` parameter in `predict(self, payload)` can vary based on the content type of the request. The `payload` parameter is parsed according to the `Content-Type` header in the request:
 
 1. For `Content-Type: application/json`, `payload` will be the parsed JSON body.
-1. For `Content-Type: multipart/form` / `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)).
+1. For `Content-Type: multipart/form-data` / `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)).
 1. For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.
 
 The `payload` parameter type will be a Python object (*lists*, *dicts*, *numbers*) if a request with a JSON payload is made:
@@ -400,11 +400,11 @@ $ curl http://***.amazonaws.com/my-api \
     -d @sample.txt
 ```
 
-The `payload` parameter type will be a `starlette.datastructures.FormData` object if a request with a `Content-Type: multipart/form` is made:
+The `payload` parameter type will be a `starlette.datastructures.FormData` object if a request with a `Content-Type: multipart/form-data` is made:
 
 ```bash
 $ curl http://***.amazonaws.com/my-api \
-    -X POST -H "Content-Type: multipart/form" \
+    -X POST -H "Content-Type: multipart/form-data" \
     -F "fieldName=@file.txt"
 ```
 
@@ -418,7 +418,7 @@ $ curl http://***.amazonaws.com/my-api \
 
 The `payload` parameter type will be a `starlette.datastructures.FormData` object if no headers are added to the request:
 
-```bashß
+```bash
 $ curl http://***.amazonaws.com/my-api \
     -X POST \
     -d @file.txt

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -383,6 +383,13 @@ $ curl http://***.amazonaws.com/my-api \
 ```
 
 ```bash
+# payload parameter is a bytes object
+$ curl http://***.amazonaws.com/my-api \
+    -X POST -H "Content-Type:" \
+    -d @sample.txt
+```
+
+```bash
 # payload parameter is a starlette.datastructures.FormData object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: multipart/form" \
@@ -393,6 +400,13 @@ $ curl http://***.amazonaws.com/my-api \
 # payload parameter is a starlette.datastructures.FormData object
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: application/x-www-form-urlencoded" \
+    -d @file.txt
+```
+
+```bash
+# payload parameter is a starlette.datastructures.FormData object
+$ curl http://***.amazonaws.com/my-api \
+    -X POST \
     -d @file.txt
 ```
 

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -75,6 +75,7 @@ class PythonPredictor:
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as from where to download the model and initialization files, or any configurable model parameters. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
 To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
+To see what values the `predict` method can return, check the [API responses](#api-responses) section.
 
 ### Examples
 
@@ -233,6 +234,7 @@ When multiple models are defined using the Predictor's `models` field, the `tens
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
 To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
+To see what values the `predict` method can return, check the [API responses](#api-responses) section.
 
 ### Examples
 
@@ -316,6 +318,7 @@ When multiple models are defined using the Predictor's `models` field, the `onnx
 For proper separation of concerns, it is recommended to use the constructor's `config` paramater for information such as configurable model parameters or download links for initialization files. You define `config` in your [API configuration](api-configuration.md), and it is passed through to your Predictor's constructor.
 
 To see what values the `payload` parameter can take, check the [API requests](#api-requests) section.
+To see what values the `predict` method can return, check the [API responses](#api-responses) section.
 
 ### Examples
 
@@ -364,9 +367,8 @@ If your application requires additional dependencies, you can install additional
 
 ## API requests
 
-The type of the `payload` parameter in `predict(self, payload)` can vary based on the content type of the request.
+The type of the `payload` parameter in `predict(self, payload)` can vary based on the content type of the request. The `payload` parameter is parsed according to the `Content-Type` header in the request:
 
-The `payload` parameter is parsed according to the `Content-Type` header in the request:
 1. For `Content-Type: application/json`, `payload` will be the parsed JSON body.
 1. For `Content-Type: multipart/form` / `Content-Type: application/x-www-form-urlencoded`, `payload` will be `starlette.datastructures.FormData` (key-value pairs where the value is a `string` for form data, or `starlette.datastructures.UploadFile` for file uploads, see [Starlette's documentation](https://www.starlette.io/requests/#request-files)).
 1. For all other `Content-Type` values, `payload` will be the raw `bytes` of the request body.

--- a/docs/deployments/predictors.md
+++ b/docs/deployments/predictors.md
@@ -76,7 +76,7 @@ For proper separation of concerns, it is recommended to use the constructor's `c
 
 Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
 
-Your API can be configured to respond with different response payload types such as `JSON`-parseable, `string`, `bytes` objects, and more. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
+Your API can be configured to respond with different types of payload such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
 
 ### Examples
 
@@ -236,7 +236,7 @@ For proper separation of concerns, it is recommended to use the constructor's `c
 
 Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
 
-Your API can be configured to respond with different response payload types such as `JSON`-parseable, `string`, `bytes` objects, and more. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
+Your API can be configured to respond with different types of payload such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
 
 ### Examples
 
@@ -321,7 +321,7 @@ For proper separation of concerns, it is recommended to use the constructor's `c
 
 Your API can accept requests with different types of payloads such as `JSON`-parseable, `bytes` or `starlette.datastructures.FormData` data. Navigate to the [API requests](#api-requests) section to learn about how headers can be used to change the type of `payload` that is passed into your `predict` function.
 
-Your API can be configured to respond with different response payload types such as `JSON`-parseable, `string`, `bytes` objects, and more. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
+Your API can be configured to respond with different types of payload such as `JSON`-parseable, `string`, and `bytes` objects. Navigate to the [API responses](#api-responses) section to learn about how your API can respond with different response codes and content-types.
 
 ### Examples
 

--- a/pkg/workloads/cortex/serve/serve.py
+++ b/pkg/workloads/cortex/serve/serve.py
@@ -31,7 +31,6 @@ from starlette.requests import Request
 from starlette.responses import Response, PlainTextResponse, JSONResponse
 from starlette.background import BackgroundTasks
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.datastructures import FormData
 
 from cortex.lib import util
 from cortex.lib.type import API, get_spec

--- a/pkg/workloads/cortex/serve/serve.py
+++ b/pkg/workloads/cortex/serve/serve.py
@@ -28,9 +28,10 @@ from fastapi import Body, FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import Response, PlainTextResponse, JSONResponse
 from starlette.background import BackgroundTasks
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.datastructures import FormData
 
 from cortex.lib import util
 from cortex.lib.type import API, get_spec
@@ -160,9 +161,15 @@ async def parse_payload(request: Request, call_next):
     if content_type.startswith("multipart/form") or content_type.startswith(
         "application/x-www-form-urlencoded"
     ):
-        request.state.payload = await request.form()
+        try:
+            request.state.payload = await request.form()
+        except Exception as e:
+            return PlainTextResponse(content=str(e), status_code=400)
     elif content_type.startswith("application/json"):
-        request.state.payload = await request.json()
+        try:
+            request.state.payload = await request.json()
+        except json.JSONDecodeError as e:
+            return JSONResponse(content={"error": str(e)}, status_code=400)
     else:
         request.state.payload = await request.body()
 


### PR DESCRIPTION
Closes #1208.

It appears that with the FastAPI web framework, throwing exceptions in the middleware is not the intended way of handling errors. It is assumed that any exceptions occurring in the middleware are gracefully handled, meaning that instead of throwing exceptions, responses are expected to be returned instead. It is therefore assumed that any exceptions occurring in the middleware are just implementation errors and thus returning the 500 status code is acceptable (aka what we've been returning so far).

The only place where the `@app.exception_handler` handlers are used is right after the middleware once an API route has already been taken (e.g. `predict` or `summary`). In order for those handlers to work, an API route handler would have to throw an exception that would match one of the handlers' exceptions.

A couple of resources that helped me with this are the following:
* https://github.com/tiangolo/fastapi/issues/1304
* https://fastapi.tiangolo.com/tutorial/middleware/
* https://github.com/tiangolo/fastapi/issues/458
* https://fastapi.tiangolo.com/tutorial/handling-errors/

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
