### PR TITLE
Fix OOM when reading files that don't fit into memory

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -148,8 +148,11 @@ func findProjectFiles(provider types.ProviderType, configPath string) ([]string,
 		ignoreFns = append(ignoreFns, cortexIgnore)
 	}
 
-	if !_flagDeployDisallowPrompt && provider != types.LocalProviderType {
-		ignoreFns = append(ignoreFns, files.PromptForFilesAboveSize(_warningFileBytes, "do you want to upload %s (%s)?"))
+	if provider != types.LocalProviderType {
+		ignoreFns = append(ignoreFns, files.ErrorOnBigFiles)
+		if !_flagDeployDisallowPrompt {
+			ignoreFns = append(ignoreFns, files.PromptForFilesAboveSize(_warningFileBytes, "do you want to upload %s (%s)?"))
+		}
 	}
 
 	projectPaths, err := files.ListDirRecursive(projectRoot, false, ignoreFns...)

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -44,6 +44,7 @@ var (
 	_warningFileCount    = 1000
 
 	_maxFileSizeBytes      int64   = 512 * 1024 * 1024
+	_maxProjectSizeBytes   int64   = 512 * 1024 * 1024
 	_maxMemoryUsagePercent float64 = 0.9
 
 	_flagDeployEnv            string
@@ -159,7 +160,7 @@ func findProjectFiles(provider types.ProviderType, configPath string) ([]string,
 	}
 
 	// must be the last appended IgnoreFn
-	ignoreFns = append(ignoreFns, files.ErrorOnProjectSizeLimit(_maxFileSizeBytes))
+	ignoreFns = append(ignoreFns, files.ErrorOnProjectSizeLimit(_maxProjectSizeBytes))
 
 	projectPaths, err := files.ListDirRecursive(projectRoot, false, ignoreFns...)
 	if err != nil {

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -158,6 +158,9 @@ func findProjectFiles(provider types.ProviderType, configPath string) ([]string,
 		ignoreFns = append(ignoreFns, files.ErrorOnBigFilesFn(_maxFileSizeBytes, _maxMemoryUsagePercent))
 	}
 
+	// must be the last appended IgnoreFn
+	ignoreFns = append(ignoreFns, files.ErrorOnProjectSizeLimit(_maxFileSizeBytes))
+
 	projectPaths, err := files.ListDirRecursive(projectRoot, false, ignoreFns...)
 	if err != nil {
 		return nil, err

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -152,10 +152,10 @@ func findProjectFiles(provider types.ProviderType, configPath string) ([]string,
 	}
 
 	if provider != types.LocalProviderType {
-		ignoreFns = append(ignoreFns, files.ErrorOnBigFilesFn(_maxFileSizeBytes, _maxMemoryUsagePercent))
 		if !_flagDeployDisallowPrompt {
 			ignoreFns = append(ignoreFns, files.PromptForFilesAboveSize(_warningFileBytes, "do you want to upload %s (%s)?"))
 		}
+		ignoreFns = append(ignoreFns, files.ErrorOnBigFilesFn(_maxFileSizeBytes, _maxMemoryUsagePercent))
 	}
 
 	projectPaths, err := files.ListDirRecursive(projectRoot, false, ignoreFns...)

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -43,8 +43,8 @@ var (
 	_warningProjectBytes = 1024 * 1024 * 10
 	_warningFileCount    = 1000
 
-	_maxFileSizeBytes      int64   = 512 * 1024 * 1024
-	_maxProjectSizeBytes   int64   = 512 * 1024 * 1024
+	_maxFileSizeBytes      int64   = 1024 * 1024 * 512
+	_maxProjectSizeBytes   int64   = 1024 * 1024 * 512
 	_maxMemoryUsagePercent float64 = 0.9
 
 	_flagDeployEnv            string
@@ -156,11 +156,12 @@ func findProjectFiles(provider types.ProviderType, configPath string) ([]string,
 		if !_flagDeployDisallowPrompt {
 			ignoreFns = append(ignoreFns, files.PromptForFilesAboveSize(_warningFileBytes, "do you want to upload %s (%s)?"))
 		}
-		ignoreFns = append(ignoreFns, files.ErrorOnBigFilesFn(_maxFileSizeBytes, _maxMemoryUsagePercent))
+		ignoreFns = append(ignoreFns,
+			files.ErrorOnBigFilesFn(_maxFileSizeBytes, _maxMemoryUsagePercent),
+			// must be the last appended IgnoreFn
+			files.ErrorOnProjectSizeLimit(_maxProjectSizeBytes),
+		)
 	}
-
-	// must be the last appended IgnoreFn
-	ignoreFns = append(ignoreFns, files.ErrorOnProjectSizeLimit(_maxProjectSizeBytes))
 
 	projectPaths, err := files.ListDirRecursive(projectRoot, false, ignoreFns...)
 	if err != nil {

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -43,6 +43,9 @@ var (
 	_warningProjectBytes = 1024 * 1024 * 10
 	_warningFileCount    = 1000
 
+	_maxFileSizeBytes      int64   = 512 * 1024 * 1024
+	_maxMemoryUsagePercent float64 = 0.9
+
 	_flagDeployEnv            string
 	_flagDeployForce          bool
 	_flagDeployDisallowPrompt bool
@@ -149,7 +152,7 @@ func findProjectFiles(provider types.ProviderType, configPath string) ([]string,
 	}
 
 	if provider != types.LocalProviderType {
-		ignoreFns = append(ignoreFns, files.ErrorOnBigFiles)
+		ignoreFns = append(ignoreFns, files.ErrorOnBigFilesFn(_maxFileSizeBytes, _maxMemoryUsagePercent))
 		if !_flagDeployDisallowPrompt {
 			ignoreFns = append(ignoreFns, files.PromptForFilesAboveSize(_warningFileBytes, "do you want to upload %s (%s)?"))
 		}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
+	github.com/shirou/gopsutil v2.20.6+incompatible
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.5.1
 	github.com/ugorji/go/codec v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ulaKkdvJtiAqsLTiPrLaXSdnVgXJKJkTxE=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shirou/gopsutil v2.20.6+incompatible h1:P37G9YH8M4vqkKcwBosp+URN5O8Tay67D2MbR361ioY=
+github.com/shirou/gopsutil v2.20.6+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
@@ -510,6 +512,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/pkg/lib/files/errors.go
+++ b/pkg/lib/files/errors.go
@@ -24,18 +24,19 @@ import (
 )
 
 const (
-	ErrCreateDir         = "files.create_dir"
-	ErrDeleteDir         = "files.delete_dir"
-	ErrReadFormFile      = "files.read_form_file"
-	ErrCreateFile        = "files.create_file"
-	ErrReadDir           = "files.read_dir"
-	ErrReadFile          = "files.read_file"
-	ErrFileAlreadyExists = "files.file_already_exists"
-	ErrUnexpected        = "files.unexpected"
-	ErrFileDoesNotExist  = "files.file_does_not_exist"
-	ErrDirDoesNotExist   = "files.dir_does_not_exist"
-	ErrNotAFile          = "files.not_a_file"
-	ErrNotADir           = "files.not_a_dir"
+	ErrCreateDir                    = "files.create_dir"
+	ErrDeleteDir                    = "files.delete_dir"
+	ErrReadFormFile                 = "files.read_form_file"
+	ErrCreateFile                   = "files.create_file"
+	ErrReadDir                      = "files.read_dir"
+	ErrReadFile                     = "files.read_file"
+	ErrInsufficientMemoryToReadFile = "files.insufficient_memory_to_read_file"
+	ErrFileAlreadyExists            = "files.file_already_exists"
+	ErrUnexpected                   = "files.unexpected"
+	ErrFileDoesNotExist             = "files.file_does_not_exist"
+	ErrDirDoesNotExist              = "files.dir_does_not_exist"
+	ErrNotAFile                     = "files.not_a_file"
+	ErrNotADir                      = "files.not_a_dir"
 )
 
 func ErrorCreateDir(path string) error {
@@ -77,6 +78,13 @@ func ErrorReadFile(path string) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrReadFile,
 		Message: fmt.Sprintf("%s: unable to read file", path),
+	})
+}
+
+func ErrorInsufficientMemoryToReadFile(path string, fileSizeBytes, availableMemBytes int64) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrInsufficientMemoryToReadFile,
+		Message: fmt.Sprintf("%s: unable to read file due to insufficient system memory; needs %s but only has %s available", path, s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
 	})
 }
 

--- a/pkg/lib/files/errors.go
+++ b/pkg/lib/files/errors.go
@@ -93,7 +93,7 @@ func ErrorFileAlreadyExists(path string) error {
 func ErrorInsufficientMemoryToReadFile(fileSizeBytes, availableMemBytes int64) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrInsufficientMemoryToReadFile,
-		Message: fmt.Sprintf("unable to read file due to insufficient system memory; needs %s but only has %s available", s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
+		Message: fmt.Sprintf("unable to read file due to insufficient system memory; needs %s but is only allowed to use %s", s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
 	})
 }
 

--- a/pkg/lib/files/errors.go
+++ b/pkg/lib/files/errors.go
@@ -31,6 +31,7 @@ const (
 	ErrReadDir                      = "files.read_dir"
 	ErrReadFile                     = "files.read_file"
 	ErrInsufficientMemoryToReadFile = "files.insufficient_memory_to_read_file"
+	ErrFileSizeLimit                = "files.file_size_limit"
 	ErrFileAlreadyExists            = "files.file_already_exists"
 	ErrUnexpected                   = "files.unexpected"
 	ErrFileDoesNotExist             = "files.file_does_not_exist"
@@ -85,6 +86,13 @@ func ErrorInsufficientMemoryToReadFile(path string, fileSizeBytes, availableMemB
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrInsufficientMemoryToReadFile,
 		Message: fmt.Sprintf("%s: unable to read file due to insufficient system memory; needs %s but only has %s available", path, s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
+	})
+}
+
+func ErrorFileSizeLimit(path string, maxFileSizeBytes int64) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrFileSizeLimit,
+		Message: fmt.Sprintf("%s: file size cannot be greater than %s", path, s.Int64ToBase2Byte(maxFileSizeBytes)),
 	})
 }
 

--- a/pkg/lib/files/errors.go
+++ b/pkg/lib/files/errors.go
@@ -90,25 +90,17 @@ func ErrorFileAlreadyExists(path string) error {
 	})
 }
 
-func ErrorInsufficientMemoryToReadFile(path string, fileSizeBytes, availableMemBytes int64) error {
-	errMsg := fmt.Sprintf("unable to read file due to insufficient system memory; needs %s but only has %s available", s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes))
-	if len(path) > 0 {
-		errMsg = fmt.Sprintf("%s: ", path) + errMsg
-	}
+func ErrorInsufficientMemoryToReadFile(fileSizeBytes, availableMemBytes int64) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrInsufficientMemoryToReadFile,
-		Message: errMsg,
+		Message: fmt.Sprintf("unable to read file due to insufficient system memory; needs %s but only has %s available", s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
 	})
 }
 
-func ErrorFileSizeLimit(path string, maxFileSizeBytes int64) error {
-	errMsg := fmt.Sprintf("file size cannot be greater than %s", s.Int64ToBase2Byte(maxFileSizeBytes))
-	if len(path) > 0 {
-		errMsg = fmt.Sprintf("%s: ", path) + errMsg
-	}
+func ErrorFileSizeLimit(maxFileSizeBytes int64) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrFileSizeLimit,
-		Message: errMsg,
+		Message: fmt.Sprintf("file size cannot be greater than %s", s.Int64ToBase2Byte(maxFileSizeBytes)),
 	})
 }
 

--- a/pkg/lib/files/errors.go
+++ b/pkg/lib/files/errors.go
@@ -30,9 +30,9 @@ const (
 	ErrCreateFile                   = "files.create_file"
 	ErrReadDir                      = "files.read_dir"
 	ErrReadFile                     = "files.read_file"
+	ErrFileAlreadyExists            = "files.file_already_exists"
 	ErrInsufficientMemoryToReadFile = "files.insufficient_memory_to_read_file"
 	ErrFileSizeLimit                = "files.file_size_limit"
-	ErrFileAlreadyExists            = "files.file_already_exists"
 	ErrUnexpected                   = "files.unexpected"
 	ErrFileDoesNotExist             = "files.file_does_not_exist"
 	ErrDirDoesNotExist              = "files.dir_does_not_exist"
@@ -82,24 +82,24 @@ func ErrorReadFile(path string) error {
 	})
 }
 
-func ErrorInsufficientMemoryToReadFile(path string, fileSizeBytes, availableMemBytes int64) error {
-	return errors.WithStack(&errors.Error{
-		Kind:    ErrInsufficientMemoryToReadFile,
-		Message: fmt.Sprintf("%s: unable to read file due to insufficient system memory; needs %s but only has %s available", path, s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
-	})
-}
-
-func ErrorFileSizeLimit(path string, maxFileSizeBytes int64) error {
-	return errors.WithStack(&errors.Error{
-		Kind:    ErrFileSizeLimit,
-		Message: fmt.Sprintf("%s: file size cannot be greater than %s", path, s.Int64ToBase2Byte(maxFileSizeBytes)),
-	})
-}
-
 func ErrorFileAlreadyExists(path string) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrFileAlreadyExists,
 		Message: fmt.Sprintf("%s: file already exists", path),
+	})
+}
+
+func ErrorInsufficientMemoryToReadFile(fileSizeBytes, availableMemBytes int64) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrInsufficientMemoryToReadFile,
+		Message: fmt.Sprintf("unable to read file due to insufficient system memory; needs %s but only has %s available", s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
+	})
+}
+
+func ErrorFileSizeLimit(maxFileSizeBytes int64) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrFileSizeLimit,
+		Message: fmt.Sprintf("file size cannot be greater than %s", s.Int64ToBase2Byte(maxFileSizeBytes)),
 	})
 }
 

--- a/pkg/lib/files/errors.go
+++ b/pkg/lib/files/errors.go
@@ -89,17 +89,25 @@ func ErrorFileAlreadyExists(path string) error {
 	})
 }
 
-func ErrorInsufficientMemoryToReadFile(fileSizeBytes, availableMemBytes int64) error {
+func ErrorInsufficientMemoryToReadFile(path string, fileSizeBytes, availableMemBytes int64) error {
+	errMsg := fmt.Sprintf("unable to read file due to insufficient system memory; needs %s but only has %s available", s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes))
+	if len(path) > 0 {
+		errMsg = fmt.Sprintf("%s: ", path) + errMsg
+	}
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrInsufficientMemoryToReadFile,
-		Message: fmt.Sprintf("unable to read file due to insufficient system memory; needs %s but only has %s available", s.Int64ToBase2Byte(fileSizeBytes), s.Int64ToBase2Byte(availableMemBytes)),
+		Message: errMsg,
 	})
 }
 
-func ErrorFileSizeLimit(maxFileSizeBytes int64) error {
+func ErrorFileSizeLimit(path string, maxFileSizeBytes int64) error {
+	errMsg := fmt.Sprintf("file size cannot be greater than %s", s.Int64ToBase2Byte(maxFileSizeBytes))
+	if len(path) > 0 {
+		errMsg = fmt.Sprintf("%s: ", path) + errMsg
+	}
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrFileSizeLimit,
-		Message: fmt.Sprintf("file size cannot be greater than %s", s.Int64ToBase2Byte(maxFileSizeBytes)),
+		Message: errMsg,
 	})
 }
 

--- a/pkg/lib/files/errors.go
+++ b/pkg/lib/files/errors.go
@@ -33,6 +33,7 @@ const (
 	ErrFileAlreadyExists            = "files.file_already_exists"
 	ErrInsufficientMemoryToReadFile = "files.insufficient_memory_to_read_file"
 	ErrFileSizeLimit                = "files.file_size_limit"
+	ErrProjectSizeLimit             = "files.project_size_limit"
 	ErrUnexpected                   = "files.unexpected"
 	ErrFileDoesNotExist             = "files.file_does_not_exist"
 	ErrDirDoesNotExist              = "files.dir_does_not_exist"
@@ -108,6 +109,13 @@ func ErrorFileSizeLimit(path string, maxFileSizeBytes int64) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrFileSizeLimit,
 		Message: errMsg,
+	})
+}
+
+func ErrorProjectSizeLimit(maxProjectSizeBytes int64) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrProjectSizeLimit,
+		Message: fmt.Sprintf("project size cannot exceed %s", s.Int64ToBase2Byte(maxProjectSizeBytes)),
 	})
 }
 

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -568,7 +568,9 @@ func ErrorOnBigFilesFn(maxFileSizeBytes int64, maxMemoryUsagePercent float64) Ig
 			fileSizeBytes := fi.Size()
 			virtual, _ := mem.VirtualMemory()
 			if int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*maxMemoryUsagePercent) {
-				return false, errors.Wrap(ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(virtual.Available)), path)
+				return false, errors.Wrap(
+					ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(float64(virtual.Total)*maxMemoryUsagePercent)-int64(virtual.Used)), path,
+				)
 			}
 			if fileSizeBytes > maxFileSizeBytes {
 				return false, errors.Wrap(ErrorFileSizeLimit(maxFileSizeBytes), path)

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -43,6 +43,7 @@ import (
 var (
 	_homeDir               string
 	_maxMemoryUsagePercent float64 = 0.9
+	_maxFileSizeBytes      int64   = 512 * 1024 * 1024
 )
 
 func Open(path string) (*os.File, error) {
@@ -118,6 +119,9 @@ func ReadFileBytesErrPath(path string, errMsgPath string) ([]byte, error) {
 	if float64(fileSizeBytes) > float64(virtual.Available) &&
 		int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*_maxMemoryUsagePercent) {
 		return nil, ErrorInsufficientMemoryToReadFile(path, fileSizeBytes, int64(virtual.Available))
+	}
+	if fileSizeBytes > _maxFileSizeBytes {
+		return nil, ErrorFileSizeLimit(path, _maxFileSizeBytes)
 	}
 
 	fileBytes, err := ioutil.ReadFile(path)

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -536,12 +536,12 @@ func ErrorOnBigFiles(path string, fi os.FileInfo) (bool, error) {
 	if !fi.IsDir() {
 		fileSizeBytes := fi.Size()
 		virtual, _ := mem.VirtualMemory()
-		if float64(fileSizeBytes) > float64(virtual.Available) &&
+		if float64(fileSizeBytes) > float64(virtual.Available) ||
 			int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*_maxMemoryUsagePercent) {
-			return false, ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(virtual.Available))
+			return false, ErrorInsufficientMemoryToReadFile("", fileSizeBytes, int64(virtual.Available))
 		}
 		if fileSizeBytes > _maxFileSizeBytes {
-			return false, ErrorFileSizeLimit(_maxFileSizeBytes)
+			return false, ErrorFileSizeLimit("", _maxFileSizeBytes)
 		}
 	}
 

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -585,9 +585,9 @@ func ErrorOnProjectSizeLimit(maxProjectSizeBytes int64) IgnoreFn {
 	return func(path string, fi os.FileInfo) (bool, error) {
 		if !fi.IsDir() {
 			filesSizeSum += fi.Size()
-		}
-		if filesSizeSum > maxProjectSizeBytes {
-			return false, ErrorProjectSizeLimit(maxProjectSizeBytes)
+			if filesSizeSum > maxProjectSizeBytes {
+				return false, ErrorProjectSizeLimit(maxProjectSizeBytes)
+			}
 		}
 		return false, nil
 	}

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -538,10 +538,10 @@ func ErrorOnBigFiles(path string, fi os.FileInfo) (bool, error) {
 		virtual, _ := mem.VirtualMemory()
 		if float64(fileSizeBytes) > float64(virtual.Available) &&
 			int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*_maxMemoryUsagePercent) {
-			return true, ErrorInsufficientMemoryToReadFile(path, fileSizeBytes, int64(virtual.Available))
+			return false, ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(virtual.Available))
 		}
 		if fileSizeBytes > _maxFileSizeBytes {
-			return true, ErrorFileSizeLimit(path, _maxFileSizeBytes)
+			return false, ErrorFileSizeLimit(_maxFileSizeBytes)
 		}
 	}
 

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -580,6 +580,19 @@ func ErrorOnBigFilesFn(maxFileSizeBytes int64, maxMemoryUsagePercent float64) Ig
 	}
 }
 
+func ErrorOnProjectSizeLimit(maxProjectSizeBytes int64) IgnoreFn {
+	filesSizeSum := int64(0)
+	return func(path string, fi os.FileInfo) (bool, error) {
+		if !fi.IsDir() {
+			filesSizeSum += fi.Size()
+		}
+		if filesSizeSum > maxProjectSizeBytes {
+			return false, ErrorProjectSizeLimit(maxProjectSizeBytes)
+		}
+		return false, nil
+	}
+}
+
 type DirsOrder string
 
 var DirsSorted DirsOrder = "sorted"

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -569,7 +569,8 @@ func ErrorOnBigFilesFn(maxFileSizeBytes int64, maxMemoryUsagePercent float64) Ig
 			virtual, _ := mem.VirtualMemory()
 			if int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*maxMemoryUsagePercent) {
 				return false, errors.Wrap(
-					ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(float64(virtual.Total)*maxMemoryUsagePercent)-int64(virtual.Used)), path,
+					ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(float64(virtual.Total)*maxMemoryUsagePercent)-int64(virtual.Used)),
+					path,
 				)
 			}
 			if fileSizeBytes > maxFileSizeBytes {

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -567,8 +567,7 @@ func ErrorOnBigFilesFn(maxFileSizeBytes int64, maxMemoryUsagePercent float64) Ig
 		if !fi.IsDir() {
 			fileSizeBytes := fi.Size()
 			virtual, _ := mem.VirtualMemory()
-			if float64(fileSizeBytes) > float64(virtual.Available) ||
-				int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*maxMemoryUsagePercent) {
+			if int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*maxMemoryUsagePercent) {
 				return false, errors.Wrap(ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(virtual.Available)), path)
 			}
 			if fileSizeBytes > maxFileSizeBytes {

--- a/pkg/lib/strings/stringify.go
+++ b/pkg/lib/strings/stringify.go
@@ -121,7 +121,11 @@ func Round(val float64, decimalPlaces int, padToDecimalPlaces int) string {
 
 // copied from https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
 func IntToBase2Byte(size int) string {
-	const unit = 1024
+	return Int64ToBase2Byte(int64(size))
+}
+
+func Int64ToBase2Byte(size int64) string {
+	const unit int64 = 1024
 	if size < unit {
 		return fmt.Sprintf("%d B", size)
 	}


### PR DESCRIPTION
When running `cortex deploy -e aws`, if the project's files don't fit into memory, then an OOM error is returned and it panics. In Go, when that happens, the panic is non-recoverable. Because of this, the program must ensure it doesn't encounter an OOM.

Wanted to use [runtime.ReadMemStats](https://golang.org/pkg/runtime/#ReadMemStats) to get the available allocable memory (looking at _HeapIdle_), but after running a few tests, it doesn't look like it's giving what we need. The stats are mainly about what the Go program uses (with GC and all that) and not about the system's available memory.

And it wasn't like we could just read the stats from `/proc` because that's platform-specific. [shirou/gopsutil](https://github.com/shirou/gopsutil) appears to be a well-maintained project that's cross-platform and gives us what we need.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
