### PR TITLE
Fix API error/status messages

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -178,6 +178,10 @@ func getAPIsInAllEnvironments() (string, error) {
 		}
 	}
 
+	if len(allSyncAPIs) == 0 && len(allAPISplitters) == 0 {
+		return console.Bold("no apis are deployed"), nil
+	}
+
 	out := ""
 	var apiSplitTable table.Table
 	var syncAPITable table.Table

--- a/cli/local/validations.go
+++ b/cli/local/validations.go
@@ -122,7 +122,7 @@ func ValidateLocalAPIs(apis []userconfig.API, projectFiles ProjectFiles, awsClie
 		api := &apis[i]
 
 		if err := spec.ValidateAPI(api, projectFiles, types.LocalProviderType, awsClient); err != nil {
-			return err
+			return errors.Wrap(err, api.Identify())
 		}
 
 		if api.Compute.CPU != nil && (api.Compute.CPU.MilliValue() > int64(dockerClient.Info.NCPU)*1000) {

--- a/pkg/operator/resources/validations.go
+++ b/pkg/operator/resources/validations.go
@@ -93,10 +93,10 @@ func ValidateClusterAPIs(apis []userconfig.API, projectFiles spec.ProjectFiles) 
 		api := &apis[i]
 		if api.Kind == userconfig.SyncAPIKind {
 			if err := spec.ValidateAPI(api, projectFiles, types.AWSProviderType, config.AWS); err != nil {
-				return errors.Wrap(err, api.Identify())
+				return err
 			}
 			if err := validateK8s(api, virtualServices, maxMem); err != nil {
-				return errors.Wrap(err, api.Identify())
+				return err
 			}
 
 			if !didPrintWarning && api.Networking.LocalPort != nil {
@@ -106,13 +106,13 @@ func ValidateClusterAPIs(apis []userconfig.API, projectFiles spec.ProjectFiles) 
 		}
 		if api.Kind == userconfig.APISplitterKind {
 			if err := spec.ValidateAPISplitter(api, types.AWSProviderType, config.AWS); err != nil {
-				return errors.Wrap(err, api.Identify())
+				return err
 			}
 			if err := checkIfAPIExists(api.APIs, withoutAPISplitter); err != nil {
 				return errors.Wrap(err, api.Identify())
 			}
 			if err := validateEndpointCollisions(api, virtualServices); err != nil {
-				return errors.Wrap(err, api.Identify())
+				return err
 			}
 		}
 	}
@@ -211,7 +211,7 @@ func validateEndpointCollisions(api *userconfig.API, virtualServices []istioclie
 		endpoints := k8s.ExtractVirtualServiceEndpoints(&virtualService)
 		for endpoint := range endpoints {
 			if s.EnsureSuffix(endpoint, "/") == s.EnsureSuffix(*api.Networking.Endpoint, "/") && virtualService.Labels["apiName"] != api.Name {
-				return errors.Wrap(spec.ErrorDuplicateEndpoint(virtualService.Labels["apiName"]), api.Identify(), userconfig.EndpointKey, endpoint)
+				return errors.Wrap(spec.ErrorDuplicateEndpoint(virtualService.Labels["apiName"]), api.Identify(), userconfig.NetworkingKey, userconfig.EndpointKey, endpoint)
 			}
 		}
 	}

--- a/pkg/operator/resources/validations.go
+++ b/pkg/operator/resources/validations.go
@@ -93,7 +93,7 @@ func ValidateClusterAPIs(apis []userconfig.API, projectFiles spec.ProjectFiles) 
 		api := &apis[i]
 		if api.Kind == userconfig.SyncAPIKind {
 			if err := spec.ValidateAPI(api, projectFiles, types.AWSProviderType, config.AWS); err != nil {
-				return err
+				return errors.Wrap(err, api.Identify())
 			}
 			if err := validateK8s(api, virtualServices, maxMem); err != nil {
 				return err

--- a/pkg/operator/resources/validations.go
+++ b/pkg/operator/resources/validations.go
@@ -96,7 +96,7 @@ func ValidateClusterAPIs(apis []userconfig.API, projectFiles spec.ProjectFiles) 
 				return errors.Wrap(err, api.Identify())
 			}
 			if err := validateK8s(api, virtualServices, maxMem); err != nil {
-				return err
+				return errors.Wrap(err, api.Identify())
 			}
 
 			if !didPrintWarning && api.Networking.LocalPort != nil {
@@ -112,7 +112,7 @@ func ValidateClusterAPIs(apis []userconfig.API, projectFiles spec.ProjectFiles) 
 				return errors.Wrap(err, api.Identify())
 			}
 			if err := validateEndpointCollisions(api, virtualServices); err != nil {
-				return err
+				return errors.Wrap(err, api.Identify())
 			}
 		}
 	}
@@ -130,7 +130,7 @@ func ValidateClusterAPIs(apis []userconfig.API, projectFiles spec.ProjectFiles) 
 
 func validateK8s(api *userconfig.API, virtualServices []istioclientnetworking.VirtualService, maxMem kresource.Quantity) error {
 	if err := validateK8sCompute(api.Compute, maxMem); err != nil {
-		return errors.Wrap(err, api.Identify(), userconfig.ComputeKey)
+		return errors.Wrap(err, userconfig.ComputeKey)
 	}
 
 	if err := validateEndpointCollisions(api, virtualServices); err != nil {
@@ -211,7 +211,7 @@ func validateEndpointCollisions(api *userconfig.API, virtualServices []istioclie
 		endpoints := k8s.ExtractVirtualServiceEndpoints(&virtualService)
 		for endpoint := range endpoints {
 			if s.EnsureSuffix(endpoint, "/") == s.EnsureSuffix(*api.Networking.Endpoint, "/") && virtualService.Labels["apiName"] != api.Name {
-				return errors.Wrap(spec.ErrorDuplicateEndpoint(virtualService.Labels["apiName"]), api.Identify(), userconfig.NetworkingKey, userconfig.EndpointKey, endpoint)
+				return errors.Wrap(spec.ErrorDuplicateEndpoint(virtualService.Labels["apiName"]), userconfig.NetworkingKey, userconfig.EndpointKey, endpoint)
 			}
 		}
 	}

--- a/pkg/operator/resources/validations.go
+++ b/pkg/operator/resources/validations.go
@@ -106,7 +106,7 @@ func ValidateClusterAPIs(apis []userconfig.API, projectFiles spec.ProjectFiles) 
 		}
 		if api.Kind == userconfig.APISplitterKind {
 			if err := spec.ValidateAPISplitter(api, types.AWSProviderType, config.AWS); err != nil {
-				return err
+				return errors.Wrap(err, api.Identify())
 			}
 			if err := checkIfAPIExists(api.APIs, withoutAPISplitter); err != nil {
 				return errors.Wrap(err, api.Identify())

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -601,22 +601,22 @@ func ValidateAPI(
 	}
 
 	if err := validatePredictor(api, projectFiles, providerType, awsClient); err != nil {
-		return errors.Wrap(err, api.Identify(), userconfig.PredictorKey)
+		return errors.Wrap(err, userconfig.PredictorKey)
 	}
 
 	if api.Autoscaling != nil { // should only be nil for local provider
 		if err := validateAutoscaling(api); err != nil {
-			return errors.Wrap(err, api.Identify(), userconfig.AutoscalingKey)
+			return errors.Wrap(err, userconfig.AutoscalingKey)
 		}
 	}
 
 	if err := validateCompute(api, providerType); err != nil {
-		return errors.Wrap(err, api.Identify(), userconfig.ComputeKey)
+		return errors.Wrap(err, userconfig.ComputeKey)
 	}
 
 	if api.UpdateStrategy != nil { // should only be nil for local provider
 		if err := validateUpdateStrategy(api.UpdateStrategy); err != nil {
-			return errors.Wrap(err, api.Identify(), userconfig.UpdateStrategyKey)
+			return errors.Wrap(err, userconfig.UpdateStrategyKey)
 		}
 	}
 

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -632,10 +632,10 @@ func ValidateAPISplitter(
 		api.Networking.Endpoint = pointer.String("/" + api.Name)
 	}
 	if err := verifyTotalWeight(api.APIs); err != nil {
-		return err
+		return errors.Wrap(err, api.Identify())
 	}
 	if err := areAPISplitterAPIsUnique(api.APIs); err != nil {
-		return err
+		return errors.Wrap(err, api.Identify())
 	}
 
 	return nil

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -632,10 +632,10 @@ func ValidateAPISplitter(
 		api.Networking.Endpoint = pointer.String("/" + api.Name)
 	}
 	if err := verifyTotalWeight(api.APIs); err != nil {
-		return errors.Wrap(err, api.Identify())
+		return err
 	}
 	if err := areAPISplitterAPIsUnique(api.APIs); err != nil {
-		return errors.Wrap(err, api.Identify())
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This PR addresses three issues:

1. When no APIs are deployed, doing a `cortex get` (with no `-e` specified) will print the API Splitter's column names instead of outputting `no apis are deployed` message.

1. For API kind `SyncAPI`, when an error is encountered, the API's identity gets printed twice instead of once. That identity has `<filepath>: <api-name> <api-kind>` format.

1. Missing `networking` key when an error with the `endpoint` field is encountered with the `APISplitter` kind.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
