### PR TITLE
Fix tensor shape validation for the TensorFlow predictor

### DIFF
--- a/cli/cmd/lib_realtime_apis.go
+++ b/cli/cmd/lib_realtime_apis.go
@@ -256,11 +256,22 @@ func describeModelInput(status *status.Status, apiEndpoint string) string {
 			for idx, dim := range inputSignature.Shape {
 				shapeStr[idx] = s.ObjFlatNoQuotes(dim)
 			}
+
+			shapeRowEntry := ""
+			if len(shapeStr) == 1 && shapeStr[0] == "scalar" {
+				shapeRowEntry = "scalar"
+			}
+			else if len(shapeStr) == 1 && shapeStr[0] == "unknown" {
+				shapeRowEntry = "unknown"
+			}
+			else {
+				shapeRowEntry = "(" + strings.Join(shapeStr, ", ") + ")"
+			}
 			rows[rowNum] = []interface{}{
 				modelName,
 				inputName,
 				inputSignature.Type,
-				"(" + strings.Join(shapeStr, ", ") + ")",
+				shapeRowEntry,
 			}
 			rowNum++
 		}

--- a/cli/cmd/lib_realtime_apis.go
+++ b/cli/cmd/lib_realtime_apis.go
@@ -260,11 +260,9 @@ func describeModelInput(status *status.Status, apiEndpoint string) string {
 			shapeRowEntry := ""
 			if len(shapeStr) == 1 && shapeStr[0] == "scalar" {
 				shapeRowEntry = "scalar"
-			}
-			else if len(shapeStr) == 1 && shapeStr[0] == "unknown" {
+			} else if len(shapeStr) == 1 && shapeStr[0] == "unknown" {
 				shapeRowEntry = "unknown"
-			}
-			else {
+			} else {
 				shapeRowEntry = "(" + strings.Join(shapeStr, ", ") + ")"
 			}
 			rows[rowNum] = []interface{}{

--- a/pkg/workloads/cortex/lib/client/tensorflow.py
+++ b/pkg/workloads/cortex/lib/client/tensorflow.py
@@ -249,7 +249,7 @@ def extract_signature(signature_def, signature_key, model_name):
             # a scalar with rank 0 and empty shape
             shape = "scalar"
         elif input_metadata["tensorShape"].get("unknownRank", False):
-            #  unknown rank and shape
+            # unknown rank and shape
             shape = "unknown"
         elif input_metadata["tensorShape"].get("dim", None):
             # known rank and known/unknown shape

--- a/pkg/workloads/cortex/lib/client/tensorflow.py
+++ b/pkg/workloads/cortex/lib/client/tensorflow.py
@@ -280,6 +280,9 @@ def create_prediction_request(signature_def, signature_key, model_name, model_in
         elif signature_def[signature_key]["inputs"][column_name]["tensorShape"].get(
             "unknownRank", False
         ):
+            # unknownRank is set to True if the model input has no rank
+            # it may lead to an undefined behavior if unknownRank is only checked for its presence
+            # so it also gets to be tested against its value
             shape = "unknown"
         else:
             shape = []

--- a/pkg/workloads/cortex/lib/client/tensorflow.py
+++ b/pkg/workloads/cortex/lib/client/tensorflow.py
@@ -297,7 +297,7 @@ def create_prediction_request(signature_def, signature_key, model_name, model_in
                     'key "{}"'.format(column_name), "expected to be a scalar", str(e)
                 ) from e
             elif shape == "unknown":
-                raise UserExceptioon(
+                raise UserException(
                     'key "{}"'.format(column_name), "can be of any rank and shape", str(e)
                 ) from e
             else:

--- a/pkg/workloads/cortex/lib/client/tensorflow.py
+++ b/pkg/workloads/cortex/lib/client/tensorflow.py
@@ -250,6 +250,10 @@ def extract_signature(signature_def, signature_key, model_name):
             shape = "scalar"
         elif input_metadata["tensorShape"].get("unknownRank", False):
             # unknown rank and shape
+            #
+            # unknownRank is set to True if the model input has no rank
+            # it may lead to an undefined behavior if unknownRank is only checked for its presence
+            # so it also gets to be tested against its value
             shape = "unknown"
         elif input_metadata["tensorShape"].get("dim", None):
             # known rank and known/unknown shape

--- a/pkg/workloads/cortex/lib/client/tensorflow.py
+++ b/pkg/workloads/cortex/lib/client/tensorflow.py
@@ -245,8 +245,25 @@ def extract_signature(signature_def, signature_key, model_name):
 
     parsed_signature = {}
     for input_name, input_metadata in signature_def_val["inputs"].items():
+        if input_metadata["tensorShape"] == {}:
+            # a scalar with rank 0 and empty shape
+            shape = "scalar"
+        elif input_metadata["tensorShape"].get("unknownRank", False):
+            #  unknown rank and shape
+            shape = "unknown"
+        elif input_metadata["tensorShape"].get("dim", None):
+            # known rank and known/unknown shape
+            shape = [int(dim["size"]) for dim in input_metadata["tensorShape"]["dim"]]
+        else:
+            raise UserException(
+                "invalid 'tensorShape' specification for input '{}' in signature key '{}' for model '{}'",
+                input_name,
+                signature_key,
+                model_name,
+            )
+
         parsed_signature[input_name] = {
-            "shape": [int(dim["size"]) for dim in input_metadata["tensorShape"]["dim"]],
+            "shape": shape if type(shape) == list else [shape],
             "type": DTYPE_TO_TF_TYPE[input_metadata["dtype"]].name,
         }
     return signature_key, parsed_signature
@@ -258,9 +275,16 @@ def create_prediction_request(signature_def, signature_key, model_name, model_in
     prediction_request.model_spec.signature_name = signature_key
 
     for column_name, value in model_input.items():
-        shape = []
-        for dim in signature_def[signature_key]["inputs"][column_name]["tensorShape"]["dim"]:
-            shape.append(int(dim["size"]))
+        if signature_def[signature_key]["inputs"][column_name]["tensorShape"] == {}:
+            shape = "scalar"
+        elif signature_def[signature_key]["inputs"][column_name]["tensorShape"].get(
+            "unknownRank", False
+        ):
+            shape = "unknown"
+        else:
+            shape = []
+            for dim in signature_def[signature_key]["inputs"][column_name]["tensorShape"]["dim"]:
+                shape.append(int(dim["size"]))
 
         sig_type = signature_def[signature_key]["inputs"][column_name]["dtype"]
 
@@ -268,9 +292,18 @@ def create_prediction_request(signature_def, signature_key, model_name, model_in
             tensor_proto = tf.compat.v1.make_tensor_proto(value, dtype=DTYPE_TO_TF_TYPE[sig_type])
             prediction_request.inputs[column_name].CopyFrom(tensor_proto)
         except Exception as e:
-            raise UserException(
-                'key "{}"'.format(column_name), "expected shape {}".format(shape), str(e)
-            ) from e
+            if shape == "scalar":
+                raise UserException(
+                    'key "{}"'.format(column_name), "expected to be a scalar", str(e)
+                ) from e
+            elif shape == "unknown":
+                raise UserExceptioon(
+                    'key "{}"'.format(column_name), "can be of any rank and shape", str(e)
+                ) from e
+            else:
+                raise UserException(
+                    'key "{}"'.format(column_name), "expected shape {}".format(shape), str(e)
+                ) from e
 
     return prediction_request
 


### PR DESCRIPTION
Fixes #1310.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
