### PR TITLE
Use eksctl to suspend auto scaling group processes

### DIFF
--- a/manager/generate_eks.py
+++ b/manager/generate_eks.py
@@ -81,6 +81,7 @@ def apply_spot_settings(nodegroup, config):
     spot_settings = {
         "name": "ng-cortex-worker-spot",
         "instanceType": "mixed",
+        "asgSuspendProcesses": ["AZRebalance"],
         "instancesDistribution": {
             "instanceTypes": config["spot_config"]["instance_distribution"],
             "onDemandBaseCapacity": config["spot_config"]["on_demand_base_capacity"],

--- a/manager/install.sh
+++ b/manager/install.sh
@@ -40,16 +40,6 @@ function ensure_eks() {
     python generate_eks.py $CORTEX_CLUSTER_CONFIG_FILE > $CORTEX_CLUSTER_WORKSPACE/eks.yaml
     eksctl create cluster --timeout=$EKSCTL_TIMEOUT --install-neuron-plugin=false -f $CORTEX_CLUSTER_WORKSPACE/eks.yaml
 
-    if [ "$CORTEX_SPOT" == "True" ]; then
-      asg_info=$(aws autoscaling describe-auto-scaling-groups --region $CORTEX_REGION --query "AutoScalingGroups[?contains(Tags[?Key==\`alpha.eksctl.io/cluster-name\`].Value, \`$CORTEX_CLUSTER_NAME\`)]|[?contains(Tags[?Key==\`alpha.eksctl.io/nodegroup-name\`].Value, \`ng-cortex-worker-spot\`)]")
-      asg_name=$(echo "$asg_info" | jq -r 'first | .AutoScalingGroupName')
-      if [ "$asg_name" = "" ] || [ "$asg_name" = "null" ]; then
-        echo -e "unable to find autoscaling group name from info:\n$asg_info"
-        exit 1
-      fi
-      aws autoscaling suspend-processes --region $CORTEX_REGION --auto-scaling-group-name $asg_name --scaling-processes AZRebalance
-    fi
-
     echo  # cluster is ready
     return
   fi


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)