### PR TITLE
Fix license plate reader example

### DIFF
--- a/examples/tensorflow/license-plate-reader/requirements.txt
+++ b/examples/tensorflow/license-plate-reader/requirements.txt
@@ -1,3 +1,5 @@
-keras-ocr==0.6.1
+keras-ocr==0.8.5
 keras==2.3.1
-tensorflow==2.1.0
+tensorflow==2.3.0
+scipy==1.4.1
+numpy==1.18.*

--- a/examples/tensorflow/license-plate-reader/utils/utils.py
+++ b/examples/tensorflow/license-plate-reader/utils/utils.py
@@ -136,8 +136,7 @@ def get_yolo_boxes(
             yolos[i] = np.array(yolos[i]).reshape((box_size, box_size, filters))
     else:
         output = model.predict_on_batch(batch_input)
-        output = [output[0][0], output[1][0], output[2][0]]
-        yolos = list(map(lambda out: out.numpy(), output))
+        yolos = [output[0][0], output[1][0], output[2][0]]
 
     boxes = []
     # decode the output of the network


### PR DESCRIPTION
Was getting the following error when it was being deployed:

```
Traceback (most recent call last):
  File "/src/cortex/lib/type/predictor.py", line 111, in initialize_impl
    return class_impl(**args)
  File "/mnt/project/predictor_lite.py", line 39, in __init__
    self.recognition_model_pipeline = keras_ocr.pipeline.Pipeline()
  File "/opt/conda/envs/env/lib/python3.6/site-packages/keras_ocr/pipeline.py", line 19, in __init__
    detector = detection.Detector()
  File "/opt/conda/envs/env/lib/python3.6/site-packages/keras_ocr/detection.py", line 590, in __init__
    sha256=weights_config['sha256'])
  File "/opt/conda/envs/env/lib/python3.6/site-packages/keras_ocr/tools.py", line 423, in download_and_verify
    assert sha256 is None or sha256 == sha256sum(filepath), 'Error occurred verifying sha256.'
AssertionError: Error occurred verifying sha256.
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/src/cortex/serve/serve.py", line 314, in start_fn
    predictor_impl = api.predictor.initialize_impl(project_dir, client, raw_api_spec, None)
  File "/src/cortex/lib/type/predictor.py", line 113, in initialize_impl
    raise UserRuntimeException(self.path, "__init__", str(e)) from e
cortex.lib.exceptions.UserRuntimeException: error: predictor_lite.py: __init__: Error occurred verifying sha256.: runtime exception
```

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (the lite and full version of the example)
