### PR TITLE
Fix unwanted error when system memory usage exceeds 90%

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -44,9 +44,8 @@ var (
 	_warningProjectBytes = 1024 * 1024 * 10
 	_warningFileCount    = 1000
 
-	_maxFileSizeBytes      int64   = 1024 * 1024 * 512
-	_maxProjectSizeBytes   int64   = 1024 * 1024 * 512
-	_maxMemoryUsagePercent float64 = 0.9
+	_maxFileSizeBytes    int64 = 1024 * 1024 * 512
+	_maxProjectSizeBytes int64 = 1024 * 1024 * 512
 
 	_flagDeployEnv            string
 	_flagDeployForce          bool
@@ -158,7 +157,7 @@ func findProjectFiles(provider types.ProviderType, configPath string) ([]string,
 			ignoreFns = append(ignoreFns, files.PromptForFilesAboveSize(_warningFileBytes, "do you want to upload %s (%s)?"))
 		}
 		ignoreFns = append(ignoreFns,
-			files.ErrorOnBigFilesFn(_maxFileSizeBytes, _maxMemoryUsagePercent),
+			files.ErrorOnBigFilesFn(_maxFileSizeBytes),
 			// must be the last appended IgnoreFn
 			files.ErrorOnProjectSizeLimit(_maxProjectSizeBytes),
 		)

--- a/pkg/lib/files/files.go
+++ b/pkg/lib/files/files.go
@@ -562,14 +562,14 @@ func PromptForFilesAboveSize(size int, promptMsgTemplate string) IgnoreFn {
 	}
 }
 
-func ErrorOnBigFilesFn(maxFileSizeBytes int64, maxMemoryUsagePercent float64) IgnoreFn {
+func ErrorOnBigFilesFn(maxFileSizeBytes int64) IgnoreFn {
 	return func(path string, fi os.FileInfo) (bool, error) {
 		if !fi.IsDir() {
 			fileSizeBytes := fi.Size()
 			virtual, _ := mem.VirtualMemory()
-			if int64(virtual.Used)+fileSizeBytes > int64(float64(virtual.Total)*maxMemoryUsagePercent) {
+			if fileSizeBytes > int64(virtual.Available) {
 				return false, errors.Wrap(
-					ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(float64(virtual.Total)*maxMemoryUsagePercent)-int64(virtual.Used)),
+					ErrorInsufficientMemoryToReadFile(fileSizeBytes, int64(virtual.Available)),
 					path,
 				)
 			}


### PR DESCRIPTION
When the system memory usage exceeds 90%, no matter how small a file within the directory of a Cortex project is (when running `cortex deploy`), it will throw an error saying the available system memory is a negative number. This PR fixes that.
```
unable to read file due to insufficient system memory; needs 128MiB but is only allowed to use -20MiB
```

---

Remove the `_maxMemoryUsagePercent` threshold that determines the cut-off on the memory availability in percentage terms - the application should not be responsible for _estimating_ how much memory the OS can allocate to the application, but instead, it should only look at how much available memory it really does have. It's the OS's job to report an allocation error.

---

checklist:

- [x] run `make test` and `make lint`
- [x] build the CLI
- [x] test the fix against a couple of cases
