### PR TITLE
Save api spec using json instead of msgpack

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -192,6 +192,11 @@ func getAPIsInAllEnvironments() (string, error) {
 		// check if any environments errorred
 		if len(errorsMap) != len(cliConfig.Environments) {
 			if len(errorsMap) == 0 {
+				mismatchedAPIMessage, err := getLocalVersionMismatchedAPIsMessage()
+				if err == nil && len(mismatchedAPIMessage) > 0 {
+					return console.Bold("no apis are deployed") + "\n\n" + mismatchedAPIMessage, nil
+				}
+
 				return console.Bold("no apis are deployed"), nil
 			}
 
@@ -281,6 +286,10 @@ func getAPIsByEnv(env cliconfig.Environment, printEnv bool) (string, error) {
 	}
 
 	if len(apisRes.RealtimeAPIs) == 0 && len(apisRes.BatchAPIs) == 0 && len(apisRes.TrafficSplitters) == 0 {
+		mismatchedAPIMessage, err := getLocalVersionMismatchedAPIsMessage()
+		if err == nil && len(mismatchedAPIMessage) > 0 {
+			return console.Bold("no apis are deployed") + "\n\n" + mismatchedAPIMessage, nil
+		}
 		return console.Bold("no apis are deployed"), nil
 	}
 
@@ -354,7 +363,7 @@ func getLocalVersionMismatchedAPIsMessage() (string, error) {
 	}
 
 	if len(mismatchedAPINames) == 1 {
-		return fmt.Sprintf("an api named %s was deployed in your local environment using a different version of the cortex cli; please delete them using `cortex delete %s` and then redeploy them\n", s.UserStr(mismatchedAPINames[0]), mismatchedAPINames[0]), nil
+		return fmt.Sprintf("an api named %s was deployed in your local environment using a different version of the cortex cli; please delete it using `cortex delete %s` and then redeploy it\n", s.UserStr(mismatchedAPINames[0]), mismatchedAPINames[0]), nil
 	}
 	return fmt.Sprintf("apis named %s were deployed in your local environment using a different version of the cortex cli; please delete them using `cortex delete API_NAME` and then redeploy them\n", s.UserStrsAnd(mismatchedAPINames)), nil
 }

--- a/cli/local/api.go
+++ b/cli/local/api.go
@@ -213,6 +213,12 @@ func FindAPISpec(apiName string) (*spec.API, error) {
 
 	var apiSpec spec.API
 	for _, specPath := range filepaths {
+		if strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
+			apiSpecVersion := GetVersionFromAPISpecFilePath(specPath)
+			if apiSpecVersion != consts.CortexVersion {
+				return nil, ErrorCortexVersionMismatch(apiName, apiSpecVersion)
+			}
+		}
 		if strings.HasSuffix(filepath.Base(specPath), "-spec.json") {
 			apiSpecVersion := GetVersionFromAPISpecFilePath(specPath)
 			if apiSpecVersion != consts.CortexVersion {
@@ -245,7 +251,7 @@ func GetVersionFromAPISpec(apiName string) (string, error) {
 	}
 
 	for _, specPath := range filepaths {
-		if strings.HasSuffix(filepath.Base(specPath), "-spec.json") {
+		if strings.HasSuffix(filepath.Base(specPath), "-spec.json") || strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
 			return GetVersionFromAPISpecFilePath(specPath), nil
 		}
 	}

--- a/cli/local/api.go
+++ b/cli/local/api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package local
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -25,7 +26,6 @@ import (
 	"github.com/cortexlabs/cortex/pkg/lib/aws"
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/files"
-	"github.com/cortexlabs/cortex/pkg/lib/msgpack"
 	"github.com/cortexlabs/cortex/pkg/lib/pointer"
 	"github.com/cortexlabs/cortex/pkg/lib/prompt"
 	"github.com/cortexlabs/cortex/pkg/lib/sets/strset"
@@ -126,7 +126,7 @@ func UpdateAPI(apiConfig *userconfig.API, configPath string, projectID string, d
 }
 
 func writeAPISpec(apiSpec *spec.API) error {
-	apiBytes, err := msgpack.Marshal(apiSpec)
+	apiBytes, err := json.Marshal(apiSpec)
 	if err != nil {
 		return err
 	}
@@ -213,7 +213,7 @@ func FindAPISpec(apiName string) (*spec.API, error) {
 
 	var apiSpec spec.API
 	for _, specPath := range filepaths {
-		if strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
+		if strings.HasSuffix(filepath.Base(specPath), "-spec.json") {
 			apiSpecVersion := GetVersionFromAPISpecFilePath(specPath)
 			if apiSpecVersion != consts.CortexVersion {
 				return nil, ErrorCortexVersionMismatch(apiName, apiSpecVersion)
@@ -223,7 +223,7 @@ func FindAPISpec(apiName string) (*spec.API, error) {
 			if err != nil {
 				return nil, errors.Wrap(err, "api", apiName)
 			}
-			err = msgpack.Unmarshal(bytes, &apiSpec)
+			err = json.Unmarshal(bytes, &apiSpec)
 			if err != nil {
 				return nil, errors.Wrap(err, "api", apiName)
 			}
@@ -245,7 +245,7 @@ func GetVersionFromAPISpec(apiName string) (string, error) {
 	}
 
 	for _, specPath := range filepaths {
-		if strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
+		if strings.HasSuffix(filepath.Base(specPath), "-spec.json") {
 			return GetVersionFromAPISpecFilePath(specPath), nil
 		}
 	}

--- a/cli/local/get.go
+++ b/cli/local/get.go
@@ -17,6 +17,7 @@ limitations under the License.
 package local
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/cortexlabs/cortex/pkg/lib/docker"
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/files"
-	"github.com/cortexlabs/cortex/pkg/lib/msgpack"
 	s "github.com/cortexlabs/cortex/pkg/lib/strings"
 	"github.com/cortexlabs/cortex/pkg/operator/schema"
 	"github.com/cortexlabs/cortex/pkg/types/spec"
@@ -73,7 +73,7 @@ func ListAPISpecs() ([]spec.API, error) {
 
 	apiSpecList := []spec.API{}
 	for _, specPath := range filepaths {
-		if !strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
+		if !strings.HasSuffix(filepath.Base(specPath), "-spec.json") {
 			continue
 		}
 
@@ -87,7 +87,7 @@ func ListAPISpecs() ([]spec.API, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "api", specPath)
 		}
-		err = msgpack.Unmarshal(bytes, &apiSpec)
+		err = json.Unmarshal(bytes, &apiSpec)
 		if err != nil {
 			return nil, errors.Wrap(err, "api", specPath)
 		}
@@ -105,7 +105,7 @@ func ListVersionMismatchedAPIs() ([]string, error) {
 
 	apiNames := []string{}
 	for _, specPath := range filepaths {
-		if !strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
+		if !strings.HasSuffix(filepath.Base(specPath), "-spec.json") || !strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
 			continue
 		}
 		apiSpecVersion := GetVersionFromAPISpecFilePath(specPath)

--- a/cli/local/get.go
+++ b/cli/local/get.go
@@ -106,7 +106,7 @@ func ListVersionMismatchedAPIs() ([]string, error) {
 	apiNames := []string{}
 	for _, specPath := range filepaths {
 		// Check msgpack for compatibility
-		if !strings.HasSuffix(filepath.Base(specPath), "-spec.json") || !strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
+		if !strings.HasSuffix(filepath.Base(specPath), "-spec.json") && !strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
 			continue
 		}
 		apiSpecVersion := GetVersionFromAPISpecFilePath(specPath)
@@ -124,7 +124,6 @@ func ListVersionMismatchedAPIs() ([]string, error) {
 		}
 		apiNames = append(apiNames, splitKey[0])
 	}
-
 	return apiNames, nil
 }
 

--- a/cli/local/get.go
+++ b/cli/local/get.go
@@ -105,6 +105,7 @@ func ListVersionMismatchedAPIs() ([]string, error) {
 
 	apiNames := []string{}
 	for _, specPath := range filepaths {
+		// Check msgpack for compatibility
 		if !strings.HasSuffix(filepath.Base(specPath), "-spec.json") || !strings.HasSuffix(filepath.Base(specPath), "-spec.msgpack") {
 			continue
 		}

--- a/pkg/lib/configreader/interface_map.go
+++ b/pkg/lib/configreader/interface_map.go
@@ -30,7 +30,7 @@ type InterfaceMapValidation struct {
 	ConvertNullToEmpty     bool
 	ScalarsOnly            bool
 	StringLeavesOnly       bool
-	StringKeysOnly         bool
+	StringKeysOnly         bool // Useful for ensuring this field is JSON parsable; validates that all maps and nested maps only use string keys
 	AllowedLeafValues      []string
 	AllowCortexResources   bool
 	RequireCortexResources bool

--- a/pkg/lib/configreader/interface_map.go
+++ b/pkg/lib/configreader/interface_map.go
@@ -139,6 +139,8 @@ func validateInterfaceMap(val map[string]interface{}, v *InterfaceMapValidation)
 			if err != nil {
 				return nil, errors.Wrap(err, key)
 			}
+
+			val[key] = stringToIntMap
 		}
 	}
 

--- a/pkg/operator/operator/storage.go
+++ b/pkg/operator/operator/storage.go
@@ -26,7 +26,7 @@ func DownloadAPISpec(apiName string, apiID string) (*spec.API, error) {
 	s3Key := spec.Key(apiName, apiID)
 	var api spec.API
 
-	if err := config.AWS.ReadMsgpackFromS3(&api, config.Cluster.Bucket, s3Key); err != nil {
+	if err := config.AWS.ReadJSONFromS3(&api, config.Cluster.Bucket, s3Key); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operator/resources/batchapi/api.go
+++ b/pkg/operator/resources/batchapi/api.go
@@ -45,7 +45,7 @@ func UpdateAPI(apiConfig *userconfig.API, projectID string) (*spec.API, string, 
 	api := spec.GetAPISpec(apiConfig, projectID, "") // Deployment ID not needed for BatchAPI spec
 
 	if prevVirtualService == nil {
-		if err := config.AWS.UploadMsgpackToS3(api, config.Cluster.Bucket, api.Key); err != nil {
+		if err := config.AWS.UploadJSONToS3(api, config.Cluster.Bucket, api.Key); err != nil {
 			return nil, "", errors.Wrap(err, "upload api spec")
 		}
 
@@ -71,7 +71,7 @@ func UpdateAPI(apiConfig *userconfig.API, projectID string) (*spec.API, string, 
 	}
 
 	if !areAPIsEqual(prevVirtualService, virtualServiceSpec(api)) {
-		if err := config.AWS.UploadMsgpackToS3(api, config.Cluster.Bucket, api.Key); err != nil {
+		if err := config.AWS.UploadJSONToS3(api, config.Cluster.Bucket, api.Key); err != nil {
 			return nil, "", errors.Wrap(err, "upload api spec")
 		}
 

--- a/pkg/operator/resources/realtimeapi/api.go
+++ b/pkg/operator/resources/realtimeapi/api.go
@@ -51,7 +51,7 @@ func UpdateAPI(apiConfig *userconfig.API, projectID string, force bool) (*spec.A
 	api := spec.GetAPISpec(apiConfig, projectID, deploymentID)
 
 	if prevDeployment == nil {
-		if err := config.AWS.UploadMsgpackToS3(api, config.Cluster.Bucket, api.Key); err != nil {
+		if err := config.AWS.UploadJSONToS3(api, config.Cluster.Bucket, api.Key); err != nil {
 			return nil, "", errors.Wrap(err, "upload api spec")
 		}
 		if err := applyK8sResources(api, prevDeployment, prevService, prevVirtualService); err != nil {
@@ -78,7 +78,7 @@ func UpdateAPI(apiConfig *userconfig.API, projectID string, force bool) (*spec.A
 		if isUpdating && !force {
 			return nil, "", ErrorAPIUpdating(api.Name)
 		}
-		if err := config.AWS.UploadMsgpackToS3(api, config.Cluster.Bucket, api.Key); err != nil {
+		if err := config.AWS.UploadJSONToS3(api, config.Cluster.Bucket, api.Key); err != nil {
 			return nil, "", errors.Wrap(err, "upload api spec")
 		}
 		if err := applyK8sResources(api, prevDeployment, prevService, prevVirtualService); err != nil {
@@ -130,7 +130,7 @@ func RefreshAPI(apiName string, force bool) (string, error) {
 
 	api = spec.GetAPISpec(api.API, api.ProjectID, k8s.RandomName())
 
-	if err := config.AWS.UploadMsgpackToS3(api, config.Cluster.Bucket, api.Key); err != nil {
+	if err := config.AWS.UploadJSONToS3(api, config.Cluster.Bucket, api.Key); err != nil {
 		return "", errors.Wrap(err, "upload api spec")
 	}
 

--- a/pkg/operator/resources/trafficsplitter/api.go
+++ b/pkg/operator/resources/trafficsplitter/api.go
@@ -39,7 +39,7 @@ func UpdateAPI(apiConfig *userconfig.API, force bool) (*spec.API, string, error)
 
 	api := spec.GetAPISpec(apiConfig, "", "")
 	if prevVirtualService == nil {
-		if err := config.AWS.UploadMsgpackToS3(api, config.Cluster.Bucket, api.Key); err != nil {
+		if err := config.AWS.UploadJSONToS3(api, config.Cluster.Bucket, api.Key); err != nil {
 			return nil, "", errors.Wrap(err, "upload api spec")
 		}
 		if err := applyK8sVirtualService(api, prevVirtualService); err != nil {
@@ -55,7 +55,7 @@ func UpdateAPI(apiConfig *userconfig.API, force bool) (*spec.API, string, error)
 	}
 
 	if !areAPIsEqual(prevVirtualService, virtualServiceSpec(api)) {
-		if err := config.AWS.UploadMsgpackToS3(api, config.Cluster.Bucket, api.Key); err != nil {
+		if err := config.AWS.UploadJSONToS3(api, config.Cluster.Bucket, api.Key); err != nil {
 			return nil, "", errors.Wrap(err, "upload api spec")
 		}
 		if err := applyK8sVirtualService(api, prevVirtualService); err != nil {

--- a/pkg/types/spec/api.go
+++ b/pkg/types/spec/api.go
@@ -103,7 +103,7 @@ func Key(apiName string, apiID string) string {
 		"apis",
 		apiName,
 		apiID,
-		consts.CortexVersion+"-spec.msgpack",
+		consts.CortexVersion+"-spec.json",
 	)
 }
 

--- a/pkg/workloads/cortex/lib/type/api.py
+++ b/pkg/workloads/cortex/lib/type/api.py
@@ -17,7 +17,6 @@ import base64
 import time
 from pathlib import Path
 import json
-import msgpack
 
 import datadog
 
@@ -163,17 +162,17 @@ class API:
 
 def get_spec(provider, storage, cache_dir, spec_path):
     if provider == "local":
-        return read_msgpack(spec_path)
+        return read_json(spec_path)
 
-    local_spec_path = os.path.join(cache_dir, "api_spec.msgpack")
+    local_spec_path = os.path.join(cache_dir, "api_spec.json")
 
     if not os.path.isfile(local_spec_path):
         _, key = S3.deconstruct_s3_path(spec_path)
         storage.download_file(key, local_spec_path)
 
-    return read_msgpack(local_spec_path)
+    return read_json(local_spec_path)
 
 
-def read_msgpack(msgpack_path):
-    with open(msgpack_path, "rb") as msgpack_file:
-        return msgpack.load(msgpack_file, raw=False)
+def read_json(json_path):
+    with open(json_path) as json_file:
+        return json.load(json_file)

--- a/pkg/workloads/cortex/serve/batch.py
+++ b/pkg/workloads/cortex/serve/batch.py
@@ -18,7 +18,6 @@ import argparse
 import inspect
 import time
 import json
-import msgpack
 import threading
 import math
 


### PR DESCRIPTION
closes #1295

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

