### PR TITLE
Add a lock around metrics recording for local apis

### DIFF
--- a/pkg/workloads/cortex/lib/type/api.py
+++ b/pkg/workloads/cortex/lib/type/api.py
@@ -117,12 +117,11 @@ class API:
             cx_logger().warn("failure encountered while publishing metrics", exc_info=True)
 
     def store_metrics_locally(self, status_code, total_time):
-        self.metrics_file_lock.acquire()
-
         status_code_series = int(status_code / 100)
         status_code_file_name = f"/mnt/workspace/{os.getpid()}.{status_code_series}XX"
         request_time_file = f"/mnt/workspace/{os.getpid()}.request_time"
 
+        self.metrics_file_lock.acquire()
         try:
             self.increment_counter_file(status_code_file_name, 1)
             self.increment_counter_file(request_time_file, total_time)

--- a/pkg/workloads/cortex/lib/type/api.py
+++ b/pkg/workloads/cortex/lib/type/api.py
@@ -48,7 +48,8 @@ class API:
             host_ip = os.environ["HOST_IP"]
             datadog.initialize(statsd_host=host_ip, statsd_port="8125")
             self.statsd = datadog.statsd
-        else:
+
+        if provider == "local":
             self.metrics_file_lock = threading.Lock()
 
     def get_cached_classes(self):
@@ -114,15 +115,17 @@ class API:
             cx_logger().warn("failure encountered while publishing metrics", exc_info=True)
 
     def store_metrics_locally(self, status_code, total_time):
-        self.metrics_file_lock.acquire()
-        status_code_series = int(status_code / 100)
+        try:
+            self.metrics_file_lock.acquire()
+            status_code_series = int(status_code / 100)
 
-        status_code_file_name = f"/mnt/workspace/{os.getpid()}.{status_code_series}XX"
-        self.increment_counter_file(status_code_file_name, 1)
+            status_code_file_name = f"/mnt/workspace/{os.getpid()}.{status_code_series}XX"
+            self.increment_counter_file(status_code_file_name, 1)
 
-        request_time_file = f"/mnt/workspace/{os.getpid()}.request_time"
-        self.increment_counter_file(request_time_file, total_time)
-        self.metrics_file_lock.release()
+            request_time_file = f"/mnt/workspace/{os.getpid()}.request_time"
+            self.increment_counter_file(request_time_file, total_time)
+        finally:
+            self.metrics_file_lock.release()
 
     def increment_counter_file(self, file_name, value):
         previous_val = 0

--- a/pkg/workloads/cortex/lib/type/api.py
+++ b/pkg/workloads/cortex/lib/type/api.py
@@ -117,14 +117,14 @@ class API:
             cx_logger().warn("failure encountered while publishing metrics", exc_info=True)
 
     def store_metrics_locally(self, status_code, total_time):
+        self.metrics_file_lock.acquire()
+
+        status_code_series = int(status_code / 100)
+        status_code_file_name = f"/mnt/workspace/{os.getpid()}.{status_code_series}XX"
+        request_time_file = f"/mnt/workspace/{os.getpid()}.request_time"
+
         try:
-            self.metrics_file_lock.acquire()
-            status_code_series = int(status_code / 100)
-
-            status_code_file_name = f"/mnt/workspace/{os.getpid()}.{status_code_series}XX"
             self.increment_counter_file(status_code_file_name, 1)
-
-            request_time_file = f"/mnt/workspace/{os.getpid()}.request_time"
             self.increment_counter_file(request_time_file, total_time)
         finally:
             self.metrics_file_lock.release()


### PR DESCRIPTION
closes #1209 

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
