### PR TITLE
Fix default cluster tag validation

### DIFF
--- a/pkg/types/clusterconfig/clusterconfig.go
+++ b/pkg/types/clusterconfig/clusterconfig.go
@@ -626,9 +626,14 @@ func (cc *Config) Validate(awsClient *aws.Client) error {
 		}
 	}
 
-	for tagName := range cc.Tags {
+	for tagName, tagValue := range cc.Tags {
 		if strings.HasPrefix(tagName, "cortex.dev/") {
-			return errors.Wrap(cr.ErrorCantHavePrefix(tagName, "cortex.dev/"), TagsKey)
+			if tagName != ClusterNameTag {
+				return errors.Wrap(cr.ErrorCantHavePrefix(tagName, "cortex.dev/"), TagsKey)
+			}
+			if tagValue != cc.ClusterName {
+				return errors.Wrap(ErrorCantOverrideDefaultTag(), TagsKey)
+			}
 		}
 	}
 	cc.Tags[ClusterNameTag] = cc.ClusterName

--- a/pkg/types/clusterconfig/errors.go
+++ b/pkg/types/clusterconfig/errors.go
@@ -52,6 +52,7 @@ const (
 	ErrInvalidInstanceType                    = "clusterconfig.invalid_instance_type"
 	ErrIOPSNotSupported                       = "clusterconfig.iops_not_supported"
 	ErrIOPSTooLarge                           = "clusterconfig.iops_too_large"
+	ErrCantOverrideDefaultTag                 = "clusterconfig.cant_override_default_tag"
 	ErrSSLCertificateARNNotFound              = "clusterconfig.ssl_certificate_arn_not_found"
 )
 
@@ -232,6 +233,13 @@ func ErrorIOPSTooLarge(iops int64, volumeSize int64) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrIOPSTooLarge,
 		Message: fmt.Sprintf("%s (%d) cannot be more than 50 times larger than %s (%d); increase `%s` or decrease `%s` in your cluster configuration file", InstanceVolumeIOPSKey, iops, InstanceVolumeSizeKey, volumeSize, InstanceVolumeSizeKey, InstanceVolumeIOPSKey),
+	})
+}
+
+func ErrorCantOverrideDefaultTag() error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrCantOverrideDefaultTag,
+		Message: fmt.Sprintf("the \"%s\" tag cannot be overridden (it is set by default, and will always be equal to your cluster name)", ClusterNameTag),
 	})
 }
 


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
