### PR TITLE
Add hydra-core and omega to requirements list for search-completer example

### DIFF
--- a/examples/pytorch/search-completer/requirements.txt
+++ b/examples/pytorch/search-completer/requirements.txt
@@ -1,3 +1,5 @@
 torch
 regex
 tqdm
+omegaconf
+hydra-core


### PR DESCRIPTION
Without these dependencies, the example doesn't run.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
