### PR TITLE
Fix order of AWS CLI credentials for all cluster commands

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -141,7 +141,12 @@ var _upCmd = &cobra.Command{
 			}
 		}
 
-		awsCreds, err := awsCredentialsForCreatingCluster(_flagClusterDisallowPrompt)
+		cachedAccessConfig, err := getClusterAccessConfig(_flagClusterDisallowPrompt)
+		if err != nil {
+			exit.Error(err)
+		}
+
+		awsCreds, err := awsCredentialsForCreatingCluster(*cachedAccessConfig, _flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -141,31 +141,29 @@ var _upCmd = &cobra.Command{
 			}
 		}
 
-		cachedAccessConfig, err := getClusterAccessConfig(_flagClusterDisallowPrompt)
+		accessConfig, err := getNewClusterAccessConfig(_flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}
 
-		awsCreds, err := awsCredentialsForManagingCluster(*cachedAccessConfig, _flagClusterDisallowPrompt)
+		awsCreds, err := awsCredentialsForManagingCluster(*accessConfig, _flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}
 
-		clusterConfig, err := getInstallClusterConfig(awsCreds, _flagClusterEnv, _flagClusterDisallowPrompt)
+		clusterConfig, err := getInstallClusterConfig(awsCreds, *accessConfig, _flagClusterEnv, _flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}
-
-		accessConfig := clusterConfig.ToAccessConfig()
 
 		awsClient, err := newAWSClient(*accessConfig.Region, awsCreds)
 		if err != nil {
 			exit.Error(err)
 		}
 
-		cacheAWSCredentials(awsCreds, accessConfig)
+		cacheAWSCredentials(awsCreds, *accessConfig)
 
-		clusterState, err := clusterstate.GetClusterState(awsClient, &accessConfig)
+		clusterState, err := clusterstate.GetClusterState(awsClient, accessConfig)
 		if err != nil {
 			exit.Error(err)
 		}
@@ -327,7 +325,7 @@ var _configureCmd = &cobra.Command{
 			}
 		}
 
-		accessConfig, err := getClusterAccessConfig(_flagClusterDisallowPrompt)
+		accessConfig, err := getClusterAccessConfigWithCache(_flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}
@@ -337,12 +335,12 @@ var _configureCmd = &cobra.Command{
 			exit.Error(err)
 		}
 
-		cacheAWSCredentials(awsCreds, *accessConfig)
-
 		awsClient, err := newAWSClient(*accessConfig.Region, awsCreds)
 		if err != nil {
 			exit.Error(err)
 		}
+
+		cacheAWSCredentials(awsCreds, *accessConfig)
 
 		clusterState, err := clusterstate.GetClusterState(awsClient, accessConfig)
 		if err != nil {
@@ -395,7 +393,7 @@ var _infoCmd = &cobra.Command{
 			}
 		}
 
-		accessConfig, err := getClusterAccessConfig(_flagClusterDisallowPrompt)
+		accessConfig, err := getClusterAccessConfigWithCache(_flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}
@@ -433,7 +431,7 @@ var _downCmd = &cobra.Command{
 			}
 		}
 
-		accessConfig, err := getClusterAccessConfig(_flagClusterDisallowPrompt)
+		accessConfig, err := getClusterAccessConfigWithCache(_flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}
@@ -564,7 +562,7 @@ var _exportCmd = &cobra.Command{
 			}
 		}
 
-		accessConfig, err := getClusterAccessConfig(_flagClusterDisallowPrompt)
+		accessConfig, err := getClusterAccessConfigWithCache(_flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -146,7 +146,7 @@ var _upCmd = &cobra.Command{
 			exit.Error(err)
 		}
 
-		awsCreds, err := awsCredentialsForCreatingCluster(*cachedAccessConfig, _flagClusterDisallowPrompt)
+		awsCreds, err := awsCredentialsForManagingCluster(*cachedAccessConfig, _flagClusterDisallowPrompt)
 		if err != nil {
 			exit.Error(err)
 		}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -151,17 +151,17 @@ var _upCmd = &cobra.Command{
 			exit.Error(err)
 		}
 
-		clusterConfig, err := getInstallClusterConfig(awsCreds, *accessConfig, _flagClusterEnv, _flagClusterDisallowPrompt)
-		if err != nil {
-			exit.Error(err)
-		}
-
 		awsClient, err := newAWSClient(*accessConfig.Region, awsCreds)
 		if err != nil {
 			exit.Error(err)
 		}
 
 		cacheAWSCredentials(awsCreds, *accessConfig)
+
+		clusterConfig, err := getInstallClusterConfig(awsCreds, *accessConfig, _flagClusterEnv, _flagClusterDisallowPrompt)
+		if err != nil {
+			exit.Error(err)
+		}
 
 		clusterState, err := clusterstate.GetClusterState(awsClient, accessConfig)
 		if err != nil {

--- a/cli/cmd/lib_aws_creds.go
+++ b/cli/cmd/lib_aws_creds.go
@@ -182,6 +182,26 @@ func awsCredentialsForManagingCluster(accessConfig clusterconfig.AccessConfig, d
 		return *awsCredentials, nil
 	}
 
+	awsCredentials, err = awsCredentialsFromEnvVars()
+	if err != nil {
+		return AWSCredentials{}, err
+	}
+
+	if awsCredentials != nil {
+		fmt.Println(fmt.Sprintf("using %s found in environment variables (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
+		return *awsCredentials, nil
+	}
+
+	awsCredentials, err = awsCredentialsFromSharedCreds()
+	if err != nil {
+		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
+	}
+
+	if awsCredentials != nil {
+		fmt.Println(fmt.Sprintf("using %s from the \"default\" profile configured via `aws configure` (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
+		return *awsCredentials, nil
+	}
+
 	awsCredentials, err = getAWSCredentialsFromCache(accessConfig)
 	if err != nil {
 		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")

--- a/cli/cmd/lib_aws_creds.go
+++ b/cli/cmd/lib_aws_creds.go
@@ -212,7 +212,7 @@ func awsCredentialsFromFlags() (*AWSCredentials, error) {
 		}
 
 		credentials.ClusterAWSAccessKeyID = _flagClusterAWSAccessKeyID
-		credentials.ClusterAWSSecretAccessKey = _flagClusterAWSAccessKeyID
+		credentials.ClusterAWSSecretAccessKey = _flagClusterAWSSecretAccessKey
 	} else {
 		credentials.ClusterAWSAccessKeyID = credentials.AWSAccessKeyID
 		credentials.ClusterAWSSecretAccessKey = credentials.AWSSecretAccessKey
@@ -297,6 +297,7 @@ func credentialsCachePath(accessConfig clusterconfig.AccessConfig) string {
 // Read AWS credentials from cache.
 // Returns nil if not found or an error is encountered.
 func awsCredentialsFromCache(accessConfig clusterconfig.AccessConfig) *AWSCredentials {
+
 	credsPath := credentialsCachePath(accessConfig)
 
 	if !files.IsFile(credsPath) {

--- a/cli/cmd/lib_aws_creds.go
+++ b/cli/cmd/lib_aws_creds.go
@@ -130,7 +130,7 @@ func detectAWSCredsInConfigFile(cmd, path string) error {
 	return nil
 }
 
-func awsCredentialsForCreatingCluster(disallowPrompt bool) (AWSCredentials, error) {
+func awsCredentialsForCreatingCluster(accessConfig clusterconfig.AccessConfig, disallowPrompt bool) (AWSCredentials, error) {
 	awsCredentials, err := awsCredentialsFromFlags()
 	if err != nil {
 		return AWSCredentials{}, err

--- a/cli/cmd/lib_aws_creds.go
+++ b/cli/cmd/lib_aws_creds.go
@@ -140,6 +140,16 @@ func awsCredentialsForCreatingCluster(disallowPrompt bool) (AWSCredentials, erro
 		return *awsCredentials, nil
 	}
 
+	awsCredentials, err = getAWSCredentialsFromCache(accessConfig)
+	if err != nil {
+		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
+	}
+
+	if awsCredentials != nil {
+		fmt.Println(fmt.Sprintf("using cached %s (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
+		return *awsCredentials, nil
+	}
+
 	awsCredentials, err = awsCredentialsFromEnvVars()
 	if err != nil {
 		return AWSCredentials{}, err
@@ -182,6 +192,16 @@ func awsCredentialsForManagingCluster(accessConfig clusterconfig.AccessConfig, d
 		return *awsCredentials, nil
 	}
 
+	awsCredentials, err = getAWSCredentialsFromCache(accessConfig)
+	if err != nil {
+		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
+	}
+
+	if awsCredentials != nil {
+		fmt.Println(fmt.Sprintf("using cached %s (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
+		return *awsCredentials, nil
+	}
+
 	awsCredentials, err = awsCredentialsFromEnvVars()
 	if err != nil {
 		return AWSCredentials{}, err
@@ -199,16 +219,6 @@ func awsCredentialsForManagingCluster(accessConfig clusterconfig.AccessConfig, d
 
 	if awsCredentials != nil {
 		fmt.Println(fmt.Sprintf("using %s from the \"default\" profile configured via `aws configure` (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
-		return *awsCredentials, nil
-	}
-
-	awsCredentials, err = getAWSCredentialsFromCache(accessConfig)
-	if err != nil {
-		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
-	}
-
-	if awsCredentials != nil {
-		fmt.Println(fmt.Sprintf("using cached %s (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
 		return *awsCredentials, nil
 	}
 

--- a/cli/cmd/lib_aws_creds.go
+++ b/cli/cmd/lib_aws_creds.go
@@ -130,58 +130,6 @@ func detectAWSCredsInConfigFile(cmd, path string) error {
 	return nil
 }
 
-func awsCredentialsForCreatingCluster(accessConfig clusterconfig.AccessConfig, disallowPrompt bool) (AWSCredentials, error) {
-	awsCredentials, err := awsCredentialsFromFlags()
-	if err != nil {
-		return AWSCredentials{}, err
-	}
-
-	if awsCredentials != nil {
-		return *awsCredentials, nil
-	}
-
-	awsCredentials, err = getAWSCredentialsFromCache(accessConfig)
-	if err != nil {
-		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
-	}
-
-	if awsCredentials != nil {
-		fmt.Println(fmt.Sprintf("using cached %s (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
-		return *awsCredentials, nil
-	}
-
-	awsCredentials, err = awsCredentialsFromEnvVars()
-	if err != nil {
-		return AWSCredentials{}, err
-	}
-
-	if awsCredentials != nil {
-		fmt.Println(fmt.Sprintf("using %s found in environment variables (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
-		return *awsCredentials, nil
-	}
-
-	awsCredentials, err = awsCredentialsFromSharedCreds()
-	if err != nil {
-		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
-	}
-
-	if awsCredentials != nil {
-		fmt.Println(fmt.Sprintf("using %s from the \"default\" profile configured via `aws configure` (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
-		return *awsCredentials, nil
-	}
-
-	if disallowPrompt {
-		return AWSCredentials{}, ErrorMissingAWSCredentials()
-	}
-
-	awsCredentials, err = awsCredentialsPrompt()
-	if err != nil {
-		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
-	}
-
-	return *awsCredentials, nil
-}
-
 func awsCredentialsForManagingCluster(accessConfig clusterconfig.AccessConfig, disallowPrompt bool) (AWSCredentials, error) {
 	awsCredentials, err := awsCredentialsFromFlags()
 	if err != nil {

--- a/cli/cmd/lib_aws_creds.go
+++ b/cli/cmd/lib_aws_creds.go
@@ -140,13 +140,9 @@ func awsCredentialsForManagingCluster(accessConfig clusterconfig.AccessConfig, d
 		return *awsCredentials, nil
 	}
 
-	awsCredentials, err = getAWSCredentialsFromCache(accessConfig)
-	if err != nil {
-		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
-	}
-
+	awsCredentials = awsCredentialsFromCache(accessConfig)
 	if awsCredentials != nil {
-		fmt.Println(fmt.Sprintf("using cached %s (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
+		fmt.Println(fmt.Sprintf("using %s from cache (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
 		return *awsCredentials, nil
 	}
 
@@ -160,10 +156,7 @@ func awsCredentialsForManagingCluster(accessConfig clusterconfig.AccessConfig, d
 		return *awsCredentials, nil
 	}
 
-	awsCredentials, err = awsCredentialsFromSharedCreds()
-	if err != nil {
-		return AWSCredentials{}, errors.Append(err, "\n\nit may be possible to avoid this error by specifying the --aws-key and --aws-secret flags")
-	}
+	awsCredentials = awsCredentialsFromSharedCreds()
 
 	if awsCredentials != nil {
 		fmt.Println(fmt.Sprintf("using %s from the \"default\" profile configured via `aws configure` (to use different credentials, specify the --aws-key and --aws-secret flags)\n", awsCredentials.MaskedString()))
@@ -267,19 +260,20 @@ func awsCredentialsFromEnvVars() (*AWSCredentials, error) {
 	return &credentials, nil
 }
 
-// Read from "default" profile from credentials specified by AWS_SHARED_CREDENTIALS_FILE (default path: ~/.aws/credentials)
-func awsCredentialsFromSharedCreds() (*AWSCredentials, error) {
+// Read from "default" profile from credentials specified by AWS_SHARED_CREDENTIALS_FILE (default path: ~/.aws/credentials).
+// Returns nil if an error is encountered.
+func awsCredentialsFromSharedCreds() *AWSCredentials {
 	credentials := AWSCredentials{}
 	accessKeyID, secretAccessKey, err := aws.GetCredentialsFromCLIConfigFile()
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	credentials.AWSAccessKeyID = accessKeyID
 	credentials.AWSSecretAccessKey = secretAccessKey
 	credentials.ClusterAWSAccessKeyID = accessKeyID
 	credentials.ClusterAWSSecretAccessKey = secretAccessKey
-	return &credentials, nil
+	return &credentials
 }
 
 func awsCredentialsPrompt() (*AWSCredentials, error) {
@@ -300,26 +294,28 @@ func credentialsCachePath(accessConfig clusterconfig.AccessConfig) string {
 	return filepath.Join(_credentialsCacheDir, fmt.Sprintf("%s-%s.json", *accessConfig.Region, *accessConfig.ClusterName))
 }
 
-func getAWSCredentialsFromCache(accessConfig clusterconfig.AccessConfig) (*AWSCredentials, error) {
+// Read AWS credentials from cache.
+// Returns nil if not found or an error is encountered.
+func awsCredentialsFromCache(accessConfig clusterconfig.AccessConfig) *AWSCredentials {
 	credsPath := credentialsCachePath(accessConfig)
 
 	if !files.IsFile(credsPath) {
-		return nil, nil
+		return nil
 	}
 
 	jsonBytes, err := files.ReadFileBytes(credsPath)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	credentials := AWSCredentials{}
 
 	err = libjson.Unmarshal(jsonBytes, &credentials)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
-	return &credentials, nil
+	return &credentials
 }
 
 func cacheAWSCredentials(awsCreds AWSCredentials, accessConfig clusterconfig.AccessConfig) error {

--- a/cli/cmd/lib_cluster_config.go
+++ b/cli/cmd/lib_cluster_config.go
@@ -172,12 +172,7 @@ func getInstallClusterConfig(awsCreds AWSCredentials, accessConfig clusterconfig
 	}
 
 	clusterConfig.ClusterName = *accessConfig.ClusterName
-	clusterConfig.Region = *&accessConfig.Region
-
-	err = clusterconfig.RegionPrompt(clusterConfig, disallowPrompt)
-	if err != nil {
-		return nil, err
-	}
+	clusterConfig.Region = accessConfig.Region
 
 	awsClient, err := newAWSClient(*clusterConfig.Region, awsCreds)
 	if err != nil {

--- a/cli/cmd/lib_cluster_config.go
+++ b/cli/cmd/lib_cluster_config.go
@@ -76,7 +76,36 @@ func readUserClusterConfigFile(clusterConfig *clusterconfig.Config) error {
 	return nil
 }
 
-func getClusterAccessConfig(disallowPrompt bool) (*clusterconfig.AccessConfig, error) {
+func getNewClusterAccessConfig(disallowPrompt bool) (*clusterconfig.AccessConfig, error) {
+	accessConfig, err := clusterconfig.DefaultAccessConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if _flagClusterConfig != "" {
+		errs := cr.ParseYAMLFile(accessConfig, clusterconfig.AccessValidation, _flagClusterConfig)
+		if errors.HasError(errs) {
+			return nil, errors.Append(errors.FirstError(errs...), fmt.Sprintf("\n\ncluster configuration schema can be found here: https://docs.cortex.dev/v/%s/cluster-management/config", consts.CortexVersionMinor))
+		}
+	}
+
+	if accessConfig.ClusterName != nil && accessConfig.Region != nil {
+		return accessConfig, nil
+	}
+
+	if disallowPrompt {
+		return nil, ErrorClusterAccessConfigOrPromptsRequired()
+	}
+
+	err = cr.ReadPrompt(accessConfig, clusterconfig.AccessPromptValidation)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessConfig, nil
+}
+
+func getClusterAccessConfigWithCache(disallowPrompt bool) (*clusterconfig.AccessConfig, error) {
 	accessConfig, err := clusterconfig.DefaultAccessConfig()
 	if err != nil {
 		return nil, err
@@ -127,7 +156,7 @@ func getClusterAccessConfig(disallowPrompt bool) (*clusterconfig.AccessConfig, e
 	return accessConfig, nil
 }
 
-func getInstallClusterConfig(awsCreds AWSCredentials, envName string, disallowPrompt bool) (*clusterconfig.Config, error) {
+func getInstallClusterConfig(awsCreds AWSCredentials, accessConfig clusterconfig.AccessConfig, envName string, disallowPrompt bool) (*clusterconfig.Config, error) {
 	clusterConfig := &clusterconfig.Config{}
 
 	err := clusterconfig.SetDefaults(clusterConfig)
@@ -141,6 +170,9 @@ func getInstallClusterConfig(awsCreds AWSCredentials, envName string, disallowPr
 			return nil, err
 		}
 	}
+
+	clusterConfig.ClusterName = *accessConfig.ClusterName
+	clusterConfig.Region = *&accessConfig.Region
 
 	err = clusterconfig.RegionPrompt(clusterConfig, disallowPrompt)
 	if err != nil {

--- a/docs/miscellaneous/security.md
+++ b/docs/miscellaneous/security.md
@@ -28,19 +28,17 @@ Cortex uses AWS credentials for 3 main purposes:
 
 ### Cluster spin-up
 
-Spinning up Cortex on your AWS account requires more permissions than Cortex needs once it's running. You can specify different credentials for each purpose in two ways (in order of precedence):
+You can specify credentials for spinning up the cluster in four ways (in order of precedence):
 
-1. You can specify `--aws-key` and `--aws-secret` flags with the command `cortex cluster up` to indicate the credentials that will be used to create your cluster. Optionally, you can specify `--cluster-aws-key` and `--cluster-aws-secret` to specify credentials which will be used by the cluster.
+1. You can specify `--aws-key` and `--aws-secret` flags with the command `cortex cluster up` to indicate the credentials that will be used to create your cluster. Optionally, you can specify `--cluster-aws-key` and `--cluster-aws-secret` to specify credentials which will be used by the cluster. When all four flags are specified, the credentials used when spinning up the cluster will not be used by the cluster itself. If `--cluster-aws-key` and `--cluster-aws-secret` flags are not specified, then they'll get set to the values of `--aws-key` and `--aws-secret` respectively.
 
 2. From your Cortex CLI cluster cache. If a cluster with the same name and region has existed before, the AWS credentials of that will now be used for the current creation of the cluster.
 
-3. You can export the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` which will be used to create your cluster. Optionally, you can export `CLUSTER_AWS_ACCESS_KEY_ID` and `CLUSTER_AWS_SECRET_ACCESS_KEY` to specify credentials which will be used by the cluster.
+3. You can export the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` which will be used to create your cluster. Optionally, you can export `CLUSTER_AWS_ACCESS_KEY_ID` and `CLUSTER_AWS_SECRET_ACCESS_KEY` to specify credentials which will be used by the cluster. When all four environment variables are set, the credentials used when spinning up the cluster will not be used by the cluster itself. If `CLUSTER_AWS_ACCESS_KEY_ID` and `CLUSTER_AWS_SECRET_ACCESS_KEY` environment variables are not set, then they'll get set to the values of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively.
 
 4. You can configure the shared AWS credentials with `aws configure` which will then be used to create your cluster.
 
 5. You can specify the AWS credentials `"aws access key id"` and `"aws secret access key"` at the CLI's prompt when requested.
-
-In either case, the credentials used when spinning up the cluster will not be used by the cluster itself, and can be safely revoked after the cluster is running. You may need credentials with similar access to run other `cortex cluster` commands, such as `cortex cluster configure`, `cortex cluster info`, and `cortex cluster down`.
 
 It is recommended to use an IAM user with the `AdministratorAccess` policy to create your cluster, since the CLI requires many permissions for this step, and the list of permissions is evolving as Cortex adds new features. If it is not possible to use `AdministratorAccess` in your existing AWS account, you could create a separate AWS account for your Cortex cluster, or you could ask someone within your organization to create the Cortex cluster for you (since `AdministratorAccess` is not required to deploy APIs to your cluster; see [CLI](#cli) below).
 

--- a/docs/miscellaneous/security.md
+++ b/docs/miscellaneous/security.md
@@ -32,7 +32,7 @@ Spinning up Cortex on your AWS account requires more permissions than Cortex nee
 
 1. You can specify `--aws-key` and `--aws-secret` flags with the command `cortex cluster up` to indicate the credentials that will be used to create your cluster. Optionally, you can specify `--cluster-aws-key` and `--cluster-aws-secret` to specify credentials which will be used by the cluster.
 
-2. From your Cortex CLI cluster cache. If a cluster with the same name and region has existed, the AWS credentials of that will now be used for the current creation of the cluster.
+2. From your Cortex CLI cluster cache. If a cluster with the same name and region has existed before, the AWS credentials of that will now be used for the current creation of the cluster.
 
 3. You can export the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` which will be used to create your cluster. Optionally, you can export `CLUSTER_AWS_ACCESS_KEY_ID` and `CLUSTER_AWS_SECRET_ACCESS_KEY` to specify credentials which will be used by the cluster.
 

--- a/docs/miscellaneous/security.md
+++ b/docs/miscellaneous/security.md
@@ -32,7 +32,13 @@ Spinning up Cortex on your AWS account requires more permissions than Cortex nee
 
 1. You can specify `--aws-key` and `--aws-secret` flags with the command `cortex cluster up` to indicate the credentials that will be used to create your cluster. Optionally, you can specify `--cluster-aws-key` and `--cluster-aws-secret` to specify credentials which will be used by the cluster.
 
-2. You can export the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` which will be used to create your cluster. Optionally, you can export `CLUSTER_AWS_ACCESS_KEY_ID` and `CLUSTER_AWS_SECRET_ACCESS_KEY` to specify credentials which will be used by the cluster.
+2. From your Cortex CLI cluster cache. If a cluster with the same name and region has existed, the AWS credentials of that will now be used for the current creation of the cluster.
+
+3. You can export the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` which will be used to create your cluster. Optionally, you can export `CLUSTER_AWS_ACCESS_KEY_ID` and `CLUSTER_AWS_SECRET_ACCESS_KEY` to specify credentials which will be used by the cluster.
+
+4. You can configure the shared AWS credentials with `aws configure` which will then be used to create your cluster.
+
+5. You can specify the AWS credentials `"aws access key id"` and `"aws secret access key"` at the CLI's prompt when requested.
 
 In either case, the credentials used when spinning up the cluster will not be used by the cluster itself, and can be safely revoked after the cluster is running. You may need credentials with similar access to run other `cortex cluster` commands, such as `cortex cluster configure`, `cortex cluster info`, and `cortex cluster down`.
 


### PR DESCRIPTION
1. Prioritize reading from credentials cache right after flags.
1. Use the same credential priority for all of the cluster commands.

---

Initially, we had this order for the cluster create command:

1. Flags.
1. Env vars.
1. Shared credentials (~/.aws).
1. Prompt.

And this order for the other cluster commands:

1. Flags.
1. Cortex cache.
1. Prompt.

_And_ now, we have this order for all cluster commands:

1. Flags.
1. Cortex cache.
1. Env vars.
1. Shared credentials (~/.aws).
1. Prompt.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
