### PR TITLE
Improve error handling for private operator timeouts

### DIFF
--- a/cli/cluster/errors.go
+++ b/cli/cluster/errors.go
@@ -54,6 +54,8 @@ func ErrorFailedToConnectOperator(originalError error, envName string, operatorU
 	msg += fmt.Sprintf("    → otherwise you can ignore this message, and prevent it in the future with `cortex env delete %s`\n", envName)
 	msg += "\nif you have a cluster running:\n"
 	msg += fmt.Sprintf("    → run `cortex cluster info --env %s` to update your environment (include `--config <cluster.yaml>` if you have a cluster configuration file)\n", envName)
+	// CORTEX_VERSION_MINOR
+	msg += "    → if you set `operator_load_balancer_scheme: internal` in your cluster configuration file, your CLI must run from within a VPC that has access to your cluster's VPC (see https://docs.cortex.dev/v/master/guides/vpc-peering)\n"
 
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrFailedToConnectOperator,

--- a/cli/cluster/lib_http_client.go
+++ b/cli/cluster/lib_http_client.go
@@ -51,21 +51,12 @@ func (oc OperatorConfig) AuthHeader() string {
 	return fmt.Sprintf("CortexAWS %s|%s", oc.AWSAccessKeyID, oc.AWSSecretAccessKey)
 }
 
-var _operatorClient = &OperatorClient{
-	Client: &http.Client{
-		Timeout: 600 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	},
-}
-
 func HTTPGet(operatorConfig OperatorConfig, endpoint string, qParams ...map[string]string) ([]byte, error) {
 	req, err := operatorRequest(operatorConfig, "GET", endpoint, nil, qParams)
 	if err != nil {
 		return nil, err
 	}
-	return _operatorClient.MakeRequest(operatorConfig, req)
+	return makeOperatorRequest(operatorConfig, req)
 }
 
 func HTTPPostObjAsJSON(operatorConfig OperatorConfig, endpoint string, requestData interface{}, qParams ...map[string]string) ([]byte, error) {
@@ -83,7 +74,7 @@ func HTTPPostJSON(operatorConfig OperatorConfig, endpoint string, jsonRequestDat
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return _operatorClient.MakeRequest(operatorConfig, req)
+	return makeOperatorRequest(operatorConfig, req)
 }
 
 func HTTPPostNoBody(operatorConfig OperatorConfig, endpoint string, qParams ...map[string]string) ([]byte, error) {
@@ -91,7 +82,7 @@ func HTTPPostNoBody(operatorConfig OperatorConfig, endpoint string, qParams ...m
 	if err != nil {
 		return nil, err
 	}
-	return _operatorClient.MakeRequest(operatorConfig, req)
+	return makeOperatorRequest(operatorConfig, req)
 }
 
 func HTTPDelete(operatorConfig OperatorConfig, endpoint string, qParams ...map[string]string) ([]byte, error) {
@@ -99,7 +90,7 @@ func HTTPDelete(operatorConfig OperatorConfig, endpoint string, qParams ...map[s
 	if err != nil {
 		return nil, err
 	}
-	return _operatorClient.MakeRequest(operatorConfig, req)
+	return makeOperatorRequest(operatorConfig, req)
 }
 
 type HTTPUploadInput struct {
@@ -139,7 +130,7 @@ func HTTPUpload(operatorConfig OperatorConfig, endpoint string, input *HTTPUploa
 	}
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	return _operatorClient.MakeRequest(operatorConfig, req)
+	return makeOperatorRequest(operatorConfig, req)
 }
 
 func addFileToMultipart(fileName string, writer *multipart.Writer, reader io.Reader) error {
@@ -185,7 +176,7 @@ func operatorRequest(operatorConfig OperatorConfig, method string, endpoint stri
 	return req, nil
 }
 
-func (client *OperatorClient) MakeRequest(operatorConfig OperatorConfig, request *http.Request) ([]byte, error) {
+func makeOperatorRequest(operatorConfig OperatorConfig, request *http.Request) ([]byte, error) {
 	if operatorConfig.Telemetry {
 		values := request.URL.Query()
 		values.Set("clientID", operatorConfig.ClientID)
@@ -194,6 +185,18 @@ func (client *OperatorClient) MakeRequest(operatorConfig OperatorConfig, request
 
 	request.Header.Set("Authorization", operatorConfig.AuthHeader())
 	request.Header.Set("CortexAPIVersion", consts.CortexVersion)
+
+	timeout := 600 * time.Second
+	if request.URL.Path == "/info" {
+		timeout = 10 * time.Second
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 
 	response, err := client.Do(request)
 	if err != nil {

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -797,6 +797,7 @@ func printInfoOperatorResponse(clusterConfig clusterconfig.Config, operatorEndpo
 
 	infoResponse, err := cluster.Info(operatorConfig)
 	if err != nil {
+		fmt.Println(clusterConfig.UserStr())
 		return err
 	}
 	infoResponse.ClusterConfig.Config = clusterConfig


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)