### PR TITLE
Change search-completer deps according to fairseq suggestion

### DIFF
--- a/examples/pytorch/search-completer/predictor.py
+++ b/examples/pytorch/search-completer/predictor.py
@@ -7,7 +7,7 @@ import tqdm
 
 class PythonPredictor:
     def __init__(self, config):
-        roberta = torch.hub.load("pytorch/fairseq", "roberta.large")
+        roberta = torch.hub.load("pytorch/fairseq", "roberta.large", force_reload=True)
         roberta.eval()
         device = "cuda" if torch.cuda.is_available() else "cpu"
         print(f"using device: {device}")

--- a/examples/pytorch/search-completer/requirements.txt
+++ b/examples/pytorch/search-completer/requirements.txt
@@ -1,5 +1,5 @@
 torch
 regex
 tqdm
-omegaconf
+dataclasses
 hydra-core


### PR DESCRIPTION
Following the suggestions in https://github.com/pytorch/fairseq/issues/2678#issuecomment-703103335.

Something to note is that even with `hydra-core` and `omegaconf` in, the project would still run. Anyway, modified it to reflect the suggestion indicated on `fairseq`.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually using the CPU only
