### PR TITLE
Override the number of parallel jobs for the CI machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ jobs:
   build-and-deploy:
     docker:
       - image: circleci/python:3.6
+    environment:
+      NUM_BUILD_PROCS: "2"
     steps:
       - checkout
       - setup_remote_docker

--- a/build/build-images.sh
+++ b/build/build-images.sh
@@ -24,7 +24,8 @@ source $ROOT/dev/util.sh
 
 # if parallel utility is installed, the docker build commands will be parallelized
 if command -v parallel &> /dev/null ; then
-  ROOT=$ROOT SHELL=$(type -p /bin/bash) parallel --will-cite --halt now,fail=1 --eta $ROOT/build/build-image.sh {} ::: "${all_images[@]}"
+  num_procs="${NUM_BUILD_PROCS:=-1}"
+  ROOT=$ROOT SHELL=$(type -p /bin/bash) parallel --will-cite --halt now,fail=1 --eta --jobs $num_procs $ROOT/build/build-image.sh {} ::: "${all_images[@]}"
 else
   for image in "${all_images[@]}"; do
     $ROOT/build/build-image.sh $image

--- a/build/push-images.sh
+++ b/build/push-images.sh
@@ -24,7 +24,8 @@ source $ROOT/dev/util.sh
 
 # if parallel utility is installed, the docker push commands will be parallelized
 if command -v parallel &> /dev/null ; then
-  ROOT=$ROOT DOCKER_USERNAME=$DOCKER_USERNAME DOCKER_PASSWORD=$DOCKER_PASSWORD SHELL=$(type -p /bin/bash) parallel --will-cite --halt now,fail=1 --eta $ROOT/build/push-image.sh {} ::: "${all_images[@]}"
+  num_procs="${NUM_BUILD_PROCS:=-1}"
+  ROOT=$ROOT DOCKER_USERNAME=$DOCKER_USERNAME DOCKER_PASSWORD=$DOCKER_PASSWORD SHELL=$(type -p /bin/bash) parallel --will-cite --halt now,fail=1 --eta $num_procs $ROOT/build/push-image.sh {} ::: "${all_images[@]}"
 else
   for image in "${all_images[@]}"; do
     $ROOT/build/push-image.sh $image

--- a/dev/registry.sh
+++ b/dev/registry.sh
@@ -178,7 +178,8 @@ elif [ "$cmd" = "update" ]; then
   fi
 
   if command -v parallel &> /dev/null ; then
-    flag_skip_push=$flag_skip_push ecr_logged_in=$ecr_logged_in ROOT=$ROOT REGISTRY_URL=$REGISTRY_URL SHELL=$(type -p /bin/bash) parallel --will-cite --halt now,fail=1 --eta build_and_push "{} latest" ::: "${images_to_build[@]}"
+    num_procs="${NUM_BUILD_PROCS:=-1}"
+    flag_skip_push=$flag_skip_push ecr_logged_in=$ecr_logged_in ROOT=$ROOT REGISTRY_URL=$REGISTRY_URL SHELL=$(type -p /bin/bash) parallel --will-cite --halt now,fail=1 --eta --jobs $num_procs build_and_push "{} latest" ::: "${images_to_build[@]}"
   else
     for image in "${images_to_build[@]}"; do
       build_and_push $image latest

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -193,6 +193,8 @@ make cli  # the binary will be placed in <path/to/cortex>/bin/cortex
 cortex-dev version  # should show "master"
 ```
 
+If you wish to parallelize the build process, the `parallel` GNU utility needs to be installed. By default, the number of parallel jobs is set to the number of cores the devbox has. To override that, set the `NUM_BUILD_PROCS` environment variable to the desired number of parallel jobs.
+
 ### Cortex cluster
 
 Start Cortex:


### PR DESCRIPTION
This PR reduces the number of parallel jobs for the CI machine from a max of 36 down to 2. This is to prevent getting 137 error codes within Docker (OOM error).

Related to https://github.com/cortexlabs/cortex/pull/1413.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
