### PR TITLE
Disallow instance types that aren't supported by NLB

### DIFF
--- a/pkg/lib/aws/elb.go
+++ b/pkg/lib/aws/elb.go
@@ -20,7 +20,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+	"github.com/cortexlabs/cortex/pkg/lib/sets/strset"
 )
+
+// https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html
+var NLBUnsupportedInstancePrefixes = strset.New("c1", "cc1", "cc2", "cg1", "cg2", "cr1", "g1", "g2", "hi1", "hs1", "m1", "m2", "m3", "t1")
 
 // returns the the first load balancer which has all of the specified tags, or nil if no load balancers match
 func (c *Client) FindLoadBalancer(tags map[string]string) (*elbv2.LoadBalancer, error) {

--- a/pkg/types/clusterconfig/clusterconfig.go
+++ b/pkg/types/clusterconfig/clusterconfig.go
@@ -654,6 +654,11 @@ func checkCortexSupport(instanceMetadata aws.InstanceMetadata) error {
 		return ErrorInstanceTypeTooSmall()
 	}
 
+	instancePrefix := strings.Split(instanceMetadata.Type, ".")[0]
+	if aws.NLBUnsupportedInstancePrefixes.Has(instancePrefix) {
+		return ErrorInstanceTypeNotSupported(instanceMetadata.Type)
+	}
+
 	if err := checkCNISupport(instanceMetadata.Type); err != nil {
 		return err
 	}


### PR DESCRIPTION
closes #1433

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
