### PR TITLE
Ensure log group is created when multiple prefixes exist for the BatchAPI kind

### DIFF
--- a/pkg/operator/resources/batchapi/logging.go
+++ b/pkg/operator/resources/batchapi/logging.go
@@ -44,23 +44,8 @@ func operatorLogStream(jobKey spec.JobKey) string {
 // Checks if log group exists before creating it
 func ensureLogGroupForAPI(apiName string) error {
 	apiNameLogGroup := logGroupNameForAPI(apiName)
-	logGroupExists := false
 
-	err := config.AWS.CloudWatchLogs().DescribeLogGroupsPages(
-		&cloudwatchlogs.DescribeLogGroupsInput{
-			LogGroupNamePrefix: aws.String(apiNameLogGroup),
-		},
-		func(page *cloudwatchlogs.DescribeLogGroupsOutput, lastPage bool) bool {
-			for _, output := range page.LogGroups {
-				if *output.LogGroupName == apiNameLogGroup {
-					logGroupExists = true
-					return false
-				}
-			}
-			return true
-		},
-	)
-
+	logGroupExists, err := config.AWS.DoesLogGroupExist(apiNameLogGroup)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/operator/resources/batchapi/logging.go
+++ b/pkg/operator/resources/batchapi/logging.go
@@ -47,7 +47,7 @@ func ensureLogGroupForAPI(apiName string) error {
 
 	logGroupExists, err := config.AWS.DoesLogGroupExist(apiNameLogGroup)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	if !logGroupExists {

--- a/pkg/operator/resources/batchapi/logging.go
+++ b/pkg/operator/resources/batchapi/logging.go
@@ -43,17 +43,31 @@ func operatorLogStream(jobKey spec.JobKey) string {
 
 // Checks if log group exists before creating it
 func ensureLogGroupForAPI(apiName string) error {
-	output, err := config.AWS.CloudWatchLogs().DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{
-		Limit:              aws.Int64(1),
-		LogGroupNamePrefix: aws.String(logGroupNameForAPI(apiName)),
-	})
+	apiNameLogGroup := logGroupNameForAPI(apiName)
+	logGroupExists := false
+
+	err := config.AWS.CloudWatchLogs().DescribeLogGroupsPages(
+		&cloudwatchlogs.DescribeLogGroupsInput{
+			LogGroupNamePrefix: aws.String(apiNameLogGroup),
+		},
+		func(page *cloudwatchlogs.DescribeLogGroupsOutput, lastPage bool) bool {
+			for _, output := range page.LogGroups {
+				if *output.LogGroupName == apiNameLogGroup {
+					logGroupExists = true
+					return false
+				}
+			}
+			return true
+		},
+	)
+
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	if len(output.LogGroups) == 0 {
+	if !logGroupExists {
 		input := &cloudwatchlogs.CreateLogGroupInput{
-			LogGroupName: aws.String(logGroupNameForAPI(apiName)),
+			LogGroupName: aws.String(apiNameLogGroup),
 		}
 
 		// There should always be a default tag. Tags are only empty when running local operator without the tags field specified in a cluster.yaml.


### PR DESCRIPTION
When a batch API is created, if the log group name is a prefix of another existing log group (that's longer in size), then while it's deploying, the log group name for our API won't get created.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
