### PR TITLE
Update batch api sample images

### DIFF
--- a/examples/batch/image-classifier/README.md
+++ b/examples/batch/image-classifier/README.md
@@ -195,9 +195,9 @@ $ curl $BATCH_API_ENDPOINT \
             "items": [
                 "https://i.imgur.com/PzXprwl.jpg",
                 "https://i.imgur.com/E4cOSLw.jpg",
-                "http://farm1.static.flickr.com/13/17868690_fe11bdc16e.jpg",
+                "https://user-images.githubusercontent.com/4365343/96516272-d40aa980-1234-11eb-949d-8e7e739b8345.jpg",
                 "https://i.imgur.com/jDimNTZ.jpg",
-                "http://farm2.static.flickr.com/1140/950904728_0d84ac956b.jpg"
+                "https://imgur.com/a/FPkyOQT"
             ],
             "batch_size": 2
         },

--- a/examples/batch/image-classifier/README.md
+++ b/examples/batch/image-classifier/README.md
@@ -197,7 +197,7 @@ $ curl $BATCH_API_ENDPOINT \
                 "https://i.imgur.com/E4cOSLw.jpg",
                 "https://user-images.githubusercontent.com/4365343/96516272-d40aa980-1234-11eb-949d-8e7e739b8345.jpg",
                 "https://i.imgur.com/jDimNTZ.jpg",
-                "https://imgur.com/a/FPkyOQT"
+                "https://i.imgur.com/WqeovVj.jpg"
             ],
             "batch_size": 2
         },


### PR DESCRIPTION
Some of the flickr urls weren't working. To address the broken links, the sample urls from have been moved from flickr to imgur and github. Sample url json files in `cortex-examples` bucket have already been updated.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
