### PR TITLE
Fix Inferentia build error by updating Inferentia

### DIFF
--- a/docs/deployments/batch-api/predictors.md
+++ b/docs/deployments/batch-api/predictors.md
@@ -145,7 +145,7 @@ dill==0.3.1.1
 fastapi==0.54.1
 joblib==0.16.0
 msgpack==1.0.0
-neuron-cc==1.0.18001.0+0.5312e6a21
+neuron-cc==1.0.20600.0+0.b426b885f
 nltk==3.5
 np-utils==0.5.12.1
 numpy==1.18.2
@@ -160,10 +160,10 @@ scipy==1.3.2
 six==1.15.0
 statsmodels==0.12.0
 sympy==1.6.2
-tensorflow==1.15.3
-tensorflow-neuron==1.15.3.1.0.1965.0
+tensorflow==1.15.4
+tensorflow-neuron==1.15.3.1.0.2043.0
 torch==1.5.1
-torch-neuron==1.5.1.1.0.1532.0
+torch-neuron==1.5.1.1.0.1721.0
 torchvision==0.6.1
 ```
 

--- a/docs/deployments/realtime-api/predictors.md
+++ b/docs/deployments/realtime-api/predictors.md
@@ -195,7 +195,7 @@ scipy==1.3.2
 six==1.15.0
 statsmodels==0.12.0
 sympy==1.6.2
-tensorflow==1.15.3
+tensorflow==1.15.4
 tensorflow-neuron==1.15.3.1.0.2043.0
 torch==1.5.1
 torch-neuron==1.5.1.1.0.1721.0

--- a/docs/deployments/realtime-api/predictors.md
+++ b/docs/deployments/realtime-api/predictors.md
@@ -180,7 +180,7 @@ dill==0.3.1.1
 fastapi==0.54.1
 joblib==0.16.0
 msgpack==1.0.0
-neuron-cc==1.0.18001.0+0.5312e6a21
+neuron-cc==1.0.20600.0+0.b426b885f
 nltk==3.5
 np-utils==0.5.12.1
 numpy==1.18.2
@@ -196,9 +196,9 @@ six==1.15.0
 statsmodels==0.12.0
 sympy==1.6.2
 tensorflow==1.15.3
-tensorflow-neuron==1.15.3.1.0.1965.0
+tensorflow-neuron==1.15.3.1.0.2043.0
 torch==1.5.1
-torch-neuron==1.5.1.1.0.1532.0
+torch-neuron==1.5.1.1.0.1721.0
 torchvision==0.6.1
 ```
 

--- a/images/neuron-rtd/Dockerfile
+++ b/images/neuron-rtd/Dockerfile
@@ -9,8 +9,8 @@ enabled=1' > /etc/yum.repos.d/neuron.repo
 RUN rpm --import https://yum.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB
 
 RUN yum install -y \
-    aws-neuron-tools-1.1.228.0 \
-    aws-neuron-runtime-1.1.1402.0 \
+    aws-neuron-tools-1.0.10616.0 \
+    aws-neuron-runtime-1.0.9197.0 \
     procps-ng-3.3.10-26.amzn2.x86_64 \
     gzip \
     tar

--- a/images/neuron-rtd/Dockerfile
+++ b/images/neuron-rtd/Dockerfile
@@ -9,8 +9,8 @@ enabled=1' > /etc/yum.repos.d/neuron.repo
 RUN rpm --import https://yum.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB
 
 RUN yum install -y \
-    aws-neuron-tools-1.0.10616.0 \
-    aws-neuron-runtime-1.0.9197.0 \
+    aws-neuron-tools-1.1.228.0 \
+    aws-neuron-runtime-1.1.1402.0 \
     procps-ng-3.3.10-26.amzn2.x86_64 \
     gzip \
     tar

--- a/images/neuron-rtd/Dockerfile
+++ b/images/neuron-rtd/Dockerfile
@@ -9,8 +9,8 @@ enabled=1' > /etc/yum.repos.d/neuron.repo
 RUN rpm --import https://yum.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB
 
 RUN yum install -y \
-    aws-neuron-tools-1.0.10616.0 \
-    aws-neuron-runtime-1.0.9197.0 \
+    aws-neuron-tools-1.0.11054.0 \
+    aws-neuron-runtime-1.0.9592.0 \
     procps-ng-3.3.10-26.amzn2.x86_64 \
     gzip \
     tar

--- a/images/python-predictor-inf/Dockerfile
+++ b/images/python-predictor-inf/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -qq && apt-get install -y -q \
     echo "deb https://apt.repos.neuron.amazonaws.com bionic main" >> /etc/apt/sources.list.d/neuron.list && \
     wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add - && \
     apt-get update -qq && apt-get install -y -q \
-    aws-neuron-tools=1.0.10616.0 \
-    aws-neuron-runtime=1.0.9197.0 && \
+    aws-neuron-tools=1.1.228.0 && \
+    aws-neuron-runtime=1.1.1402.0 \
     apt-get clean -qq && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/opt/aws/neuron/bin/:$PATH
@@ -74,9 +74,9 @@ RUN test "${SLIM}" = "true" || ( \
             libxtst6 \
         && apt-get clean -qq && rm -rf /var/lib/apt/lists/* \
         && pip install --no-cache-dir --extra-index-url https://pip.repos.neuron.amazonaws.com \
-            neuron-cc==1.0.18001.0+0.5312e6a21 \
-            tensorflow-neuron==1.15.3.1.0.1965.0 \
-            torch-neuron==1.5.1.1.0.1532.0 \
+            neuron-cc==1.0.20600.0+0.b426b885f \
+            tensorflow-neuron==1.15.3.1.0.2043.0 \
+            torch-neuron==1.5.1.1.0.1721.0 \
             numpy==1.18.2 \
             scipy==1.3.2 \
             six==1.15.0 \

--- a/images/python-predictor-inf/Dockerfile
+++ b/images/python-predictor-inf/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -qq && apt-get install -y -q \
     echo "deb https://apt.repos.neuron.amazonaws.com bionic main" >> /etc/apt/sources.list.d/neuron.list && \
     wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add - && \
     apt-get update -qq && apt-get install -y -q \
-    aws-neuron-tools=1.1.228.0 && \
-    aws-neuron-runtime=1.1.1402.0 \
+    aws-neuron-tools=1.1.228.0 \
+    aws-neuron-runtime=1.1.1402.0 && \
     apt-get clean -qq && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/opt/aws/neuron/bin/:$PATH

--- a/images/tensorflow-serving-inf/Dockerfile
+++ b/images/tensorflow-serving-inf/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update -qq && apt-get install -y -q \
     echo "deb https://apt.repos.neuron.amazonaws.com bionic main" >> /etc/apt/sources.list.d/neuron.list && \
     wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add - && \
     apt-get update -qq && apt-get install -y -q \
-    aws-neuron-tools=1.0.10616.0 \
-    aws-neuron-runtime=1.0.9197.0 \
-    tensorflow-model-server-neuron=1.15.0.1.0.1965.0 && \
+    aws-neuron-tools=1.1.228.0 \
+    aws-neuron-runtime=1.1.1402.0 \
+    tensorflow-model-server-neuron=1.15.0.1.0.2043.0 && \
     apt-get clean -qq && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/opt/aws/neuron/bin/:$PATH


### PR DESCRIPTION
Fix build error for Inferentia that was caused by not having updated Inferentia drivers/frameworks to the latest.

An example of a build error can be found in https://app.circleci.com/pipelines/github/cortexlabs/cortex/6687/workflows/348d4af9-a44d-44fb-99ed-72fcdffae0d7/jobs/9011.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
