### PR TITLE
Use --data-binary option instead of -d for octet-stream curls in docs

### DIFF
--- a/docs/deployments/realtime-api/predictors.md
+++ b/docs/deployments/realtime-api/predictors.md
@@ -511,7 +511,7 @@ The `payload` parameter type will be a `bytes` object if a request with a `Conte
 ```bash
 $ curl http://***.amazonaws.com/my-api \
     -X POST -H "Content-Type: application/octet-stream" \
-    -d @file.bin
+    --data-binary @file.bin
 ```
 
 The `payload` parameter type will be a `bytes` object if a request doesn't have the `Content-Type` set:


### PR DESCRIPTION
Related to #1550.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (`-d` vs `--data-binary` on an image)
