### PR TITLE
Fix predictor __init__ staggering

### DIFF
--- a/pkg/workloads/cortex/lib/api/predictor.py
+++ b/pkg/workloads/cortex/lib/api/predictor.py
@@ -52,9 +52,6 @@ from cortex.lib.model import (
     ModelsTree,  # only when num workers = 1
 )
 
-# concurrency
-from cortex.lib.concurrency import FileLock
-
 # model validation
 from cortex.lib.model import validate_model_paths
 
@@ -245,8 +242,7 @@ class Predictor:
             validations = PYTHON_CLASS_VALIDATION
 
         try:
-            with FileLock("/run/init_stagger.lock"):
-                impl = self._load_module("cortex_predictor", os.path.join(project_dir, self.path))
+            impl = self._load_module("cortex_predictor", os.path.join(project_dir, self.path))
         except CortexException as e:
             e.wrap("error in " + self.path)
             raise

--- a/pkg/workloads/cortex/serve/serve.py
+++ b/pkg/workloads/cortex/serve/serve.py
@@ -35,10 +35,9 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from cortex.lib import util
 from cortex.lib.api import API, get_api
 from cortex.lib.log import cx_logger as logger
-from cortex.lib.concurrency import LockedFile
+from cortex.lib.concurrency import FileLock, LockedFile
 from cortex.lib.storage import S3, LocalStorage
 from cortex.lib.exceptions import UserRuntimeException
-from cortex.lib.concurrency import FileLock
 
 API_SUMMARY_MESSAGE = (
     "make a prediction by sending a post request to this endpoint with a json payload"


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
