### PR TITLE
Fix document denoiser example (on Keras)

### DIFF
--- a/examples/keras/document-denoiser/requirements.txt
+++ b/examples/keras/document-denoiser/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.18.0
 requests==2.22.0
 opencv-python==4.1.2.30
 keras==2.3.1
+h5py==2.10.0


### PR DESCRIPTION
Since `h5py` isn't locked to a specific version, it was installing the latest version (3.x) of it, which no longer works with Keras 2.3.1. Reverting it to the latest 2.x version fixes the issue. As reported in https://github.com/tensorflow/tensorflow/issues/44467.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
