### PR TITLE
Force pip version 19

### DIFF
--- a/images/onnx-predictor-cpu/Dockerfile
+++ b/images/onnx-predictor-cpu/Dockerfile
@@ -33,7 +33,7 @@ RUN curl "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.s
     rm -rf ~/.cache ~/miniconda.sh
 
 # split the conda installations because the dev boxes have limited memory
-RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip && \
+RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip=19.* && \
     /opt/conda/bin/conda clean -a && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.env && \

--- a/images/onnx-predictor-gpu/Dockerfile
+++ b/images/onnx-predictor-gpu/Dockerfile
@@ -33,7 +33,7 @@ RUN curl "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.s
     rm -rf ~/.cache ~/miniconda.sh
 
 # split the conda installations because the dev boxes have limited memory
-RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip && \
+RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip=19.* && \
     /opt/conda/bin/conda clean -a && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.env && \

--- a/images/python-predictor-cpu/Dockerfile
+++ b/images/python-predictor-cpu/Dockerfile
@@ -33,7 +33,7 @@ RUN curl "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.s
     rm -rf ~/.cache ~/miniconda.sh
 
 # split the conda installations because the dev boxes have limited memory
-RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip && \
+RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip=19.* && \
     /opt/conda/bin/conda clean -a && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.env && \

--- a/images/python-predictor-gpu/Dockerfile
+++ b/images/python-predictor-gpu/Dockerfile
@@ -35,7 +35,7 @@ RUN curl "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.s
     rm -rf ~/.cache ~/miniconda.sh
 
 # split the conda installations because the dev boxes have limited memory
-RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip && \
+RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip=19.* && \
     /opt/conda/bin/conda clean -a && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.env && \

--- a/images/python-predictor-inf/Dockerfile
+++ b/images/python-predictor-inf/Dockerfile
@@ -43,7 +43,7 @@ RUN curl "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.s
     rm -rf ~/.cache ~/miniconda.sh
 
 # split the conda installations because the dev boxes have limited memory
-RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip && \
+RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip=19.* && \
     /opt/conda/bin/conda clean -a && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.env && \

--- a/images/tensorflow-predictor/Dockerfile
+++ b/images/tensorflow-predictor/Dockerfile
@@ -33,7 +33,7 @@ RUN curl "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.s
     rm -rf ~/.cache ~/miniconda.sh
 
 # split the conda installations because the dev boxes have limited memory
-RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip && \
+RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip=19.* && \
     /opt/conda/bin/conda clean -a && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.env && \

--- a/pkg/workloads/cortex/client/cortex/client.py
+++ b/pkg/workloads/cortex/client/cortex/client.py
@@ -116,7 +116,7 @@ class Client:
             )
 
             if not is_python_set:
-                conda_packages = [f"python={actual_version}"] + conda_packages
+                conda_packages = [f"python={actual_version}", "pip=19.*"] + conda_packages
 
         if len(requirements) > 0:
             with open(project_dir / "requirements.txt", "w") as requirements_file:


### PR DESCRIPTION
Conda installs pip 20.* by default which uses the latest resolver. The new pip dependency resolver is more strict. For example:

```
ERROR: Cannot install keras==2.4.3, scikit-image==0.17.2, scikit-learn==0.23.2, scipy==1.5.2, statsmodels==0.12.0 and tensorflow-cpu==2.3.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested scipy==1.5.2
    keras 2.4.3 depends on scipy>=0.14
    scikit-image 0.17.2 depends on scipy>=1.0.1
    scikit-learn 0.23.2 depends on scipy>=0.19.1
    statsmodels 0.12.0 depends on scipy>=1.1
    tensorflow-cpu 2.3.0 depends on scipy==1.4.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```

Pip 19 is more permissive. Force the default pip version to use version 19 for now.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ ] update examples
- [ ] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
- [ ] cherry-pick into release branches if applicable
- [ ] alert the dev team if the dev environment changed
