### PR TITLE
Add debugger makefile command for operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,24 @@ operator-local-gcp:
 	@$(MAKE) operator-stop-gcp || true
 	@./dev/operator_local.sh --operator-only --gcp || true
 
+# start local operator and attach the delve debugger to it (in server mode)
+operator-local-aws-dbg:
+	@$(MAKE) operator-stop || true
+	@./dev/operator_local_debugger.sh --aws || true
+operator-local-gcp-dbg:
+	@$(MAKE) operator-stop || true
+	@./dev/operator_local_debugger.sh --gcp || true
+
 # configure kubectl to point to the cluster specified in dev/config/cluster-[aws|gcp].yaml
 kubectl-aws:
 	@eval $$(python3 ./manager/cluster_config_env.py ./dev/config/cluster-aws.yaml) && eksctl utils write-kubeconfig --cluster="$$CORTEX_CLUSTER_NAME" --region="$$CORTEX_REGION" | grep -v "saved kubeconfig as" | grep -v "using region" | grep -v "eksctl version" || true
 kubectl-gcp:
 	@eval $$(python3 ./manager/cluster_config_env.py ./dev/config/cluster-gcp.yaml) && gcloud container clusters get-credentials "$$CORTEX_CLUSTER_NAME" --zone "$$CORTEX_ZONE" --project "$$CORTEX_PROJECT" 2>&1 | grep -v "Fetching cluster" | grep -v "kubeconfig entry generated" || true
+
+# configure kubectl to point to the cluster specified in dev/config/cluster.yaml
+.PHONY: kubectl
+kubectl:
+	@eval $$(python3 ./manager/cluster_config_env.py ./dev/config/cluster.yaml) && eksctl utils write-kubeconfig --cluster="$$CORTEX_CLUSTER_NAME" --region="$$CORTEX_REGION" | grep -v "saved kubeconfig as" | grep -v "using region" | grep -v "eksctl version" || true
 
 cluster-up-aws:
 	@$(MAKE) images-all-aws

--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ operator-local-gcp:
 	@./dev/operator_local.sh --operator-only --gcp || true
 
 # start local operator and attach the delve debugger to it (in server mode)
-operator-local-aws-dbg:
+operator-local-dbg-aws:
 	@$(MAKE) operator-stop || true
 	@./dev/operator_local_debugger.sh --aws || true
-operator-local-gcp-dbg:
+operator-local-dbg-gcp:
 	@$(MAKE) operator-stop || true
 	@./dev/operator_local_debugger.sh --gcp || true
 

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ registry-clean-local:
 tools:
 	@go get -u -v golang.org/x/lint/golint
 	@go get -u -v github.com/VojtechVitek/rerun/cmd/rerun
+	@go get -u -v github.com/go-delve/delve/cmd/dlv
 	@python3 -m pip install black 'pydoc-markdown>=3.0.0,<4.0.0'
 	@if [[ "$$OSTYPE" == "darwin"* ]]; then brew install parallel; elif [[ "$$OSTYPE" == "linux"* ]]; then sudo apt-get install -y parallel; else echo "your operating system is not supported"; fi
 

--- a/build/lint.sh
+++ b/build/lint.sh
@@ -71,6 +71,8 @@ fi
 output=$(cd "$ROOT" && find . -type f \
 ! -path "./vendor/*" \
 ! -path "**/.vscode/*" \
+! -path "**/.idea/*" \
+! -path "**/.history/*" \
 ! -path "**/__pycache__/*" \
 ! -path "./examples/*" \
 ! -path "./dev/config/*" \
@@ -97,6 +99,8 @@ if [ "$is_release_branch" = "true" ]; then
   ! -path "./build/lint.sh" \
   ! -path "./vendor/*" \
   ! -path "**/.vscode/*" \
+  ! -path "**/.idea/*" \
+  ! -path "**/.history/*" \
   ! -path "**/__pycache__/*" \
   ! -path "./docs/contributing/development.md" \
   ! -path "./dev/config/*" \
@@ -118,6 +122,8 @@ if [ "$is_release_branch" = "true" ]; then
   ! -path "./dev/*" \
   ! -path "./vendor/*" \
   ! -path "**/.vscode/*" \
+  ! -path "**/.idea/*" \
+  ! -path "**/.history/*" \
   ! -path "**/__pycache__/*" \
   ! -path "./dev/config/*" \
   ! -path "./bin/*" \
@@ -181,6 +187,8 @@ fi
 # Check for trailing whitespace
 output=$(cd "$ROOT" && find . -type f \
 ! -path "./vendor/*" \
+! -path "**/.idea/*" \
+! -path "**/.history/*" \
 ! -path "**/.vscode/*" \
 ! -path "**/__pycache__/*" \
 ! -path "./dev/config/*" \
@@ -198,6 +206,8 @@ fi
 # Check for missing new line at end of file
 output=$(cd "$ROOT" && find . -type f \
 ! -path "./vendor/*" \
+! -path "**/.idea/*" \
+! -path "**/.history/*" \
 ! -path "**/.vscode/*" \
 ! -path "**/__pycache__/*" \
 ! -path "./dev/config/*" \
@@ -216,6 +226,8 @@ fi
 output=$(cd "$ROOT" && find . -type f \
 ! -path "./vendor/*" \
 ! -path "**/.vscode/*" \
+! -path "**/.idea/*" \
+! -path "**/.history/*" \
 ! -path "**/__pycache__/*" \
 ! -path "./dev/config/*" \
 ! -path "./bin/*" \
@@ -232,6 +244,8 @@ fi
 # Check for new line(s) at beginning of file
 output=$(cd "$ROOT" && find . -type f \
 ! -path "./vendor/*" \
+! -path "**/.idea/*" \
+! -path "**/.history/*" \
 ! -path "**/.vscode/*" \
 ! -path "**/__pycache__/*" \
 ! -path "./dev/config/*" \

--- a/dev/operator_local_debugger.sh
+++ b/dev/operator_local_debugger.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright 2020 Cortex Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+arg1=${1:-""}
+
+provider=""
+if [ "$arg1" = "--aws" ]; then
+  provider="aws"
+elif [ "$arg1" = "--gcp" ]; then
+  provider="gcp"
+else
+  echo "provider must be set: either pass in the --aws or the --gcp flag"
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. >/dev/null && pwd)"
+DEBUG_CMD="dlv --listen=:2345 --headless=true --api-version=2 debug $ROOT/pkg/operator"
+
+kill $(pgrep -f "${DEBUG_CMD}") >/dev/null 2>&1 || true
+kill $(pgrep -f __debug_bin) >/dev/null 2>&1 || true
+
+eval $(python3 $ROOT/manager/cluster_config_env.py "$ROOT/dev/config/cluster-${provider}.yaml")
+
+if [ "$provider" = "aws" ]; then
+  export CORTEX_DEV_DEFAULT_PREDICTOR_IMAGE_REGISTRY="$CORTEX_DEV_DEFAULT_PREDICTOR_IMAGE_REGISTRY_AWS"
+  export CLUSTER_AWS_ACCESS_KEY_ID="${CLUSTER_AWS_ACCESS_KEY_ID:-$AWS_ACCESS_KEY_ID}"
+  export CLUSTER_AWS_SECRET_ACCESS_KEY="${CLUSTER_AWS_SECRET_ACCESS_KEY:-$AWS_SECRET_ACCESS_KEY}"
+else
+  export CORTEX_DEV_DEFAULT_PREDICTOR_IMAGE_REGISTRY="$CORTEX_DEV_DEFAULT_PREDICTOR_IMAGE_REGISTRY_GCP"
+fi
+
+python3 $ROOT/dev/update_cli_config.py "$HOME/.cortex/cli.yaml" "${CORTEX_CLUSTER_NAME}-${provider}" "$provider" "http://localhost:8888"
+
+cp -r $ROOT/dev/config/cluster-${provider}.yaml ~/.cortex/cluster-dev.yaml
+
+if grep -qiP '^telemetry:\s*false\s*$' ~/.cortex/cli.yaml; then
+  echo "telemetry: false" >> ~/.cortex/cluster-dev.yaml
+fi
+
+export CORTEX_OPERATOR_IN_CLUSTER=false
+export CORTEX_CLUSTER_CONFIG_PATH=~/.cortex/cluster-dev.yaml
+
+mkdir -p $ROOT/bin
+
+echo 'starting local operator in debug mode...' && eval "${DEBUG_CMD}"

--- a/dev/operator_local_debugger.sh
+++ b/dev/operator_local_debugger.sh
@@ -29,7 +29,7 @@ else
 fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. >/dev/null && pwd)"
-DEBUG_CMD="dlv --listen=:2345 --headless=true --api-version=2 debug $ROOT/pkg/operator"
+DEBUG_CMD="dlv --listen=:2345 --headless=true --api-version=2 debug $ROOT/pkg/operator --output ${ROOT}/bin/__debug_bin"
 
 kill $(pgrep -f "${DEBUG_CMD}") >/dev/null 2>&1 || true
 kill $(pgrep -f __debug_bin) >/dev/null 2>&1 || true
@@ -56,5 +56,4 @@ export CORTEX_OPERATOR_IN_CLUSTER=false
 export CORTEX_CLUSTER_CONFIG_PATH=~/.cortex/cluster-dev.yaml
 
 mkdir -p $ROOT/bin
-
 echo 'starting local operator in debug mode...' && eval "${DEBUG_CMD}"


### PR DESCRIPTION
- Adds `make operator-local-dbg` command
- Excludes some common folders from the linting script (`.history` and `.idea`)

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update examples
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
- [x] cherry-pick into release branches if applicable
- [x] alert the dev team if the dev environment changed
