### PR TITLE
Improve registry.sh script UX

### DIFF
--- a/dev/registry.sh
+++ b/dev/registry.sh
@@ -187,6 +187,22 @@ function cleanup_ecr() {
   done
 }
 
+function validate_env() {
+  local provider=$1
+
+  if [ "$provider" = "aws" ]; then
+    if [[ -z ${AWS_REGION} ]] || [[ -z ${AWS_ACCOUNT_ID} ]]; then
+      echo "error: environment variables AWS_REGION and AWS_ACCOUNT_ID should be exported in dev/config/env.sh"
+      exit 1
+    fi
+  elif [ "$provider" = "gcp" ]; then
+    if [[ -z ${GCP_PROJECT_ID} ]]; then
+      echo "error: environment variables GCP_PROJECT_ID should be exported in dev/config/env.sh"
+      exit 1
+    fi
+  fi
+}
+
 # export functions for parallel command
 export -f build_and_push
 export -f push
@@ -194,6 +210,9 @@ export -f build
 export -f blue_echo
 export -f green_echo
 export -f registry_login
+
+# validate environment is correctly set on env.sh
+validate_env "$provider"
 
 # usage: registry.sh clean --provider aws|gcp|local
 if [ "$cmd" = "clean" ]; then

--- a/dev/registry.sh
+++ b/dev/registry.sh
@@ -24,8 +24,6 @@ source $ROOT/dev/config/env.sh
 source $ROOT/dev/util.sh
 
 GCR_HOST=${GCR_HOST:-"gcr.io"}
-
-# set variables to empty strings if they do not exist
 GCP_PROJECT_ID=${GCP_PROJECT_ID:-}
 AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-}
 AWS_REGION=${AWS_REGION:-}
@@ -191,12 +189,12 @@ function validate_env() {
   local provider=$1
 
   if [ "$provider" = "aws" ]; then
-    if [[ -z ${AWS_REGION} ]] || [[ -z ${AWS_ACCOUNT_ID} ]]; then
+    if [ -z ${AWS_REGION} ] || [ -z ${AWS_ACCOUNT_ID} ]; then
       echo "error: environment variables AWS_REGION and AWS_ACCOUNT_ID should be exported in dev/config/env.sh"
       exit 1
     fi
   elif [ "$provider" = "gcp" ]; then
-    if [[ -z ${GCP_PROJECT_ID} ]]; then
+    if [ -z ${GCP_PROJECT_ID} ]; then
       echo "error: environment variables GCP_PROJECT_ID should be exported in dev/config/env.sh"
       exit 1
     fi

--- a/dev/registry.sh
+++ b/dev/registry.sh
@@ -25,6 +25,11 @@ source $ROOT/dev/util.sh
 
 GCR_HOST=${GCR_HOST:-"gcr.io"}
 
+# set variables to empty strings if they do not exist
+GCP_PROJECT_ID=${GCP_PROJECT_ID:-}
+AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-}
+AWS_REGION=${AWS_REGION:-}
+
 provider="local"
 include_slim="false"
 positional_args=()


### PR DESCRIPTION
With the recent GCP merge the `make image-<type>-<provider>` commands require that all provider specific flags are set in `dev/config/env.sh`. They can currently be set as empty, but this seems unnecessary.

This PR improves the UX in 2 ways:
- If building for a specific provider, only that provider's env variables are required (the others do not need to be set)
- Add validation to check if provider specific env variables are set

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update examples
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://docs.cortex.dev/v/master) after merging)
- [x] cherry-pick into release branches if applicable
- [x] alert the dev team if the dev environment changed
