### PR TITLE
Generic fixes

### DIFF
--- a/cli/cmd/lib_realtime_apis.go
+++ b/cli/cmd/lib_realtime_apis.go
@@ -476,7 +476,17 @@ func parseAPITFLiveReloadingSummary(summary *schema.APITFLiveReloadingSummary) (
 		}
 	}
 
-	_, usesCortexDefaultModelName := summary.ModelMetadata[consts.SingleModelName]
+	usesCortexDefaultModelName := false
+	for modelID := range summary.ModelMetadata {
+		modelName, _, err := getModelFromModelID(modelID)
+		if err != nil {
+			return "", err
+		}
+		if modelName == consts.SingleModelName {
+			usesCortexDefaultModelName = true
+			break
+		}
+	}
 
 	t := table.Table{
 		Headers: []table.Header{

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -89,7 +89,7 @@ var _logsCmd = &cobra.Command{
 			gcpReq.URL.RawQuery = queryValues.Encode()
 
 			gcpLogsURL := gcpReq.URL.String()
-			consoleOutput := console.Bold(fmt.Sprintf("api %s logs: ", apiName)) + gcpLogsURL
+			consoleOutput := console.Bold(fmt.Sprintf("visit the following link to view logs for api %s: ", apiName)) + gcpLogsURL
 			fmt.Println(consoleOutput)
 		}
 

--- a/pkg/types/spec/utils.go
+++ b/pkg/types/spec/utils.go
@@ -158,7 +158,7 @@ func validateDirModels(modelPath string, api userconfig.API, projectDir string, 
 	modelNames := []string{}
 	modelDirPathLength := len(slices.RemoveEmpties(strings.Split(dirPrefix, "/")))
 	for _, path := range modelDirPaths {
-		splitPath := strings.Split(path, "/")
+		splitPath := slices.RemoveEmpties(strings.Split(path, "/"))
 		modelNames = append(modelNames, splitPath[modelDirPathLength])
 	}
 	modelNames = slices.UniqueStrings(modelNames)


### PR DESCRIPTION
1. Layout bug: when the `predictor.model_path` field is specified for the TensorFlow predictor with the LR enabled, doing a `cortex get` would list the `_cortex_default` model instead of hiding it.
1. If a "/" would be present at the beginning/end of a model path as specified with the `predictor.models.dir` field, the `cortex deploy` would then fail.
1. When calling the `client.stream_api_logs` method for a GCP environment, the output message wasn't very clear.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
