### PR TITLE
Error if no environments are configured for cx get

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -137,6 +137,14 @@ var _getCmd = &cobra.Command{
 
 				return out + jobTable, nil
 			} else {
+				envs, err := listConfiguredEnvs()
+				if err != nil {
+					return "", err
+				}
+				if len(envs) == 0 {
+					return "", ErrorNoAvailableEnvironment()
+				}
+
 				if wasEnvFlagProvided(cmd) {
 					env, err := ReadOrConfigureEnv(envName)
 					if err != nil {


### PR DESCRIPTION

checklist:

- [ ] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
