### PR TITLE
Fix cortex get output -v

### DIFF
--- a/pkg/types/userconfig/api.go
+++ b/pkg/types/userconfig/api.go
@@ -402,7 +402,7 @@ func (models *MultiModels) UserStr() string {
 		sb.WriteString(fmt.Sprintf("%s: %s\n", ModelsDirKey, *models.Dir))
 	}
 	if models.SignatureKey != nil {
-		sb.WriteString(fmt.Sprintf("%s: %s\n", ModelsDirKey, *models.SignatureKey))
+		sb.WriteString(fmt.Sprintf("%s: %s\n", ModelsSignatureKeyKey, *models.SignatureKey))
 	}
 	if models.CacheSize != nil {
 		sb.WriteString(fmt.Sprintf("%s: %s\n", ModelsCacheSizeKey, s.Int32(*models.CacheSize)))


### PR DESCRIPTION
Output of `cortex get <api-name> -v` isn't entirely correct.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
