### PR TITLE
Prevent the user from specifying non-s3/gcs model paths

### DIFF
--- a/pkg/types/spec/errors.go
+++ b/pkg/types/spec/errors.go
@@ -65,6 +65,7 @@ const (
 	ErrS3DirIsEmpty   = "spec.s3_dir_is_empty"
 
 	ErrModelPathNotDirectory      = "spec.model_path_not_directory"
+	ErrInvalidModelPathProvider   = "spec.invalid_model_path_provider"
 	ErrInvalidPythonModelPath     = "spec.invalid_python_model_path"
 	ErrInvalidTensorFlowModelPath = "spec.invalid_tensorflow_model_path"
 	ErrInvalidONNXModelPath       = "spec.invalid_onnx_model_path"
@@ -298,6 +299,13 @@ func ErrorModelPathNotDirectory(modelPath string) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrModelPathNotDirectory,
 		Message: fmt.Sprintf("%s: model path must be a directory", modelPath),
+	})
+}
+
+func ErrorInvalidModelPathProvider(modelPath string) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrInvalidModelPathProvider,
+		Message: fmt.Sprintf("%s: model path must be an S3 path (e.g. s3://bucket/my-dir/) or a GCS path (e.g. gs://bucket/my-dir)", modelPath),
 	})
 }
 

--- a/pkg/types/spec/utils.go
+++ b/pkg/types/spec/utils.go
@@ -86,6 +86,16 @@ func surgeOrUnavailableValidator(str string) (string, error) {
 	return str, nil
 }
 
+func checkForInvalidBucketProvider(modelPath string) (string, error) {
+	s3Path := strings.HasPrefix(modelPath, "s3://")
+	gcsPath := strings.HasPrefix(modelPath, "gs://")
+
+	if !s3Path && !gcsPath {
+		return "", ErrorInvalidModelPathProvider(modelPath)
+	}
+	return modelPath, nil
+}
+
 type errorForPredictorTypeFn func(string, []string) error
 
 func generateErrorForPredictorTypeFn(api *userconfig.API) errorForPredictorTypeFn {

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -606,18 +606,16 @@ func multiModelValidation(fieldName string) *cr.StructFieldValidation {
 				{
 					StructField: "Path",
 					StringPtrValidation: &cr.StringPtrValidation{
-						Required:        false,
-						InvalidPrefixes: []string{".", "./", "/"},
-						Validator:       checkForInvalidBucketProvider,
+						Required:  false,
+						Validator: checkForInvalidBucketProvider,
 					},
 				},
 				multiModelPathsValidation(),
 				{
 					StructField: "Dir",
 					StringPtrValidation: &cr.StringPtrValidation{
-						Required:        false,
-						InvalidPrefixes: []string{".", "./", "/"},
-						Validator:       checkForInvalidBucketProvider,
+						Required:  false,
+						Validator: checkForInvalidBucketProvider,
 					},
 				},
 				{
@@ -665,10 +663,9 @@ func multiModelPathsValidation() *cr.StructFieldValidation {
 					{
 						StructField: "Path",
 						StringValidation: &cr.StringValidation{
-							Required:        true,
-							AllowEmpty:      false,
-							InvalidPrefixes: []string{".", "./", "/"},
-							Validator:       checkForInvalidBucketProvider,
+							Required:   true,
+							AllowEmpty: false,
+							Validator:  checkForInvalidBucketProvider,
 						},
 					},
 					{

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -606,14 +606,18 @@ func multiModelValidation(fieldName string) *cr.StructFieldValidation {
 				{
 					StructField: "Path",
 					StringPtrValidation: &cr.StringPtrValidation{
-						Required: false,
+						Required:        false,
+						InvalidPrefixes: []string{".", "./", "/"},
+						Validator:       checkForInvalidBucketProvider,
 					},
 				},
 				multiModelPathsValidation(),
 				{
 					StructField: "Dir",
 					StringPtrValidation: &cr.StringPtrValidation{
-						Required: false,
+						Required:        false,
+						InvalidPrefixes: []string{".", "./", "/"},
+						Validator:       checkForInvalidBucketProvider,
 					},
 				},
 				{
@@ -661,8 +665,10 @@ func multiModelPathsValidation() *cr.StructFieldValidation {
 					{
 						StructField: "Path",
 						StringValidation: &cr.StringValidation{
-							Required:   true,
-							AllowEmpty: false,
+							Required:        true,
+							AllowEmpty:      false,
+							InvalidPrefixes: []string{".", "./", "/"},
+							Validator:       checkForInvalidBucketProvider,
 						},
 					},
 					{


### PR DESCRIPTION
Fixes #1817.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
