### PR TITLE
Update install.md

### DIFF
--- a/docs/clusters/gcp/install.md
+++ b/docs/clusters/gcp/install.md
@@ -76,4 +76,5 @@ image_manager: quay.io/cortexlabs/manager:0.27.0
 image_downloader: quay.io/cortexlabs/downloader:0.27.0
 image_istio_proxy: quay.io/cortexlabs/istio-proxy:0.27.0
 image_istio_pilot: quay.io/cortexlabs/istio-pilot:0.27.0
+image_google_pause: quay.io/cortexlabs/google-pause:0.27.0
 ```

--- a/docs/clusters/gcp/install.md
+++ b/docs/clusters/gcp/install.md
@@ -74,8 +74,6 @@ The docker images used by the Cortex cluster can also be overridden, although th
 image_operator: quay.io/cortexlabs/operator:0.27.0
 image_manager: quay.io/cortexlabs/manager:0.27.0
 image_downloader: quay.io/cortexlabs/downloader:0.27.0
-image_statsd: quay.io/cortexlabs/statsd:0.27.0
 image_istio_proxy: quay.io/cortexlabs/istio-proxy:0.27.0
 image_istio_pilot: quay.io/cortexlabs/istio-pilot:0.27.0
-image_pause: quay.io/cortexlabs/pause:0.27.0
 ```


### PR DESCRIPTION
It seems that the following two dependencies are no longer in use. They throw an error when explicitly included, and so should probably be removed.

image_statsd: quay.io/cortexlabs/statsd:0.27.0
image_pause: quay.io/cortexlabs/pause:0.27.0
