### PR TITLE
Wait nginx to be ready first when API's starting

### DIFF
--- a/pkg/cortex/serve/poll/readiness.sh
+++ b/pkg/cortex/serve/poll/readiness.sh
@@ -16,7 +16,7 @@
 
 while true; do
     procs_ready="$(ls /mnt/workspace/proc-*-ready.txt 2>/dev/null | wc -l)"
-    if [ "$CORTEX_PROCESSES_PER_REPLICA" = "$procs_ready" ]; then
+    if [ "$CORTEX_PROCESSES_PER_REPLICA" = "$procs_ready" ] && curl --silent "localhost:${CORTEX_SERVING_PORT}/nginx_status" >/dev/null; then
         touch /mnt/workspace/api_readiness.txt
         break
     fi


### PR DESCRIPTION

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
