### PR TITLE
Skip nvidia plugin installation on eksctl

### DIFF
--- a/manager/install.sh
+++ b/manager/install.sh
@@ -207,7 +207,7 @@ function create_eks() {
 
   echo -e "￮ spinning up the cluster (this will take about 25 minutes) ...\n"
   python generate_eks.py $CORTEX_CLUSTER_CONFIG_FILE > /workspace/eks.yaml
-  eksctl create cluster --timeout=$EKSCTL_TIMEOUT --install-neuron-plugin=false -f /workspace/eks.yaml
+  eksctl create cluster --timeout=$EKSCTL_TIMEOUT --install-neuron-plugin=false --install-nvidia-plugin=false -f /workspace/eks.yaml
   echo
 
   suspend_az_rebalance


### PR DESCRIPTION

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

