### PR TITLE
Increase batch jobs timeout on E2E tests

### DIFF
--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -72,7 +72,7 @@ def pytest_configure(config):
                 os.environ.get("CORTEX_TEST_REALTIME_DEPLOY_TIMEOUT", 120)
             ),
             "batch_deploy_timeout": int(os.environ.get("CORTEX_TEST_BATCH_DEPLOY_TIMEOUT", 30)),
-            "batch_job_timeout": int(os.environ.get("CORTEX_TEST_BATCH_JOB_TIMEOUT", 120)),
+            "batch_job_timeout": int(os.environ.get("CORTEX_TEST_BATCH_JOB_TIMEOUT", 200)),
         },
     }
 


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

