### PR TITLE
Lock uvloop to version 0.14.0 due to Python Runtime version requirement

### DIFF
--- a/pkg/cortex/serve/serve.requirements.txt
+++ b/pkg/cortex/serve/serve.requirements.txt
@@ -2,4 +2,5 @@ grpcio==1.32.0
 python-multipart==0.0.5
 requests==2.24.0
 uvicorn==0.11.8
+uvloop==0.14.0
 pyyaml==5.3.1


### PR DESCRIPTION
We need to lock [uvloop](https://pypi.org/project/uvloop/#history) package to its previous version 0.14.0. The latest one which got released ~15 hours ago requires the python runtime to be upgraded to >= 3.7. We have 3.6.9.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
