### PR TITLE
Disable dynamic batcher for non python predictor types

### DIFF
--- a/pkg/cortex/serve/cortex_internal/lib/api/api.py
+++ b/pkg/cortex/serve/cortex_internal/lib/api/api.py
@@ -53,8 +53,11 @@ class API:
         self.statsd = datadog.statsd
 
     @property
-    def server_side_batching_enabled(self):
-        return self.api_spec["predictor"].get("server_side_batching") is not None
+    def python_server_side_batching_enabled(self):
+        return (
+            self.api_spec["predictor"].get("server_side_batching") is not None
+            and self.api_spec["predictor"]["type"] == "python"
+        )
 
     def metric_dimensions_with_id(self):
         return [

--- a/pkg/cortex/serve/cortex_internal/serve/serve.py
+++ b/pkg/cortex/serve/cortex_internal/serve/serve.py
@@ -15,11 +15,9 @@
 import asyncio
 import inspect
 import json
-import math
 import os
-import sys
 import re
-import threading
+import sys
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -300,7 +298,7 @@ def start_fn():
         local_cache["predictor_impl"] = predictor_impl
         local_cache["predict_fn_args"] = inspect.getfullargspec(predictor_impl.predict).args
 
-        if api.server_side_batching_enabled:
+        if api.python_server_side_batching_enabled:
             dynamic_batching_config = api.api_spec["predictor"]["server_side_batching"]
             local_cache["dynamic_batcher"] = DynamicBatcher(
                 predictor_impl,


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

