### PR TITLE
Revert version upgrade for TF Serving

### DIFF
--- a/dev/versions.md
+++ b/dev/versions.md
@@ -143,7 +143,7 @@ python versions in our pip dependencies (e.g. [tensorflow](https://pypi.org/proj
 ## TensorFlow / TensorFlow Serving
 
 1. Find the latest release on [GitHub](https://github.com/tensorflow/tensorflow/releases)
-1. Search the codebase for the current minor TensorFlow version (e.g. `2.4`) and update versions as appropriate
+1. Search the codebase for the current minor TensorFlow version (e.g. `2.3`) and update versions as appropriate
 1. Update the version for libnvinfer in `images/tensorflow-serving-gpu/Dockerfile` dockerfile as appropriate (https://www.tensorflow.org/install/gpu)
 
 Note: it's ok if example training notebooks aren't upgraded, as long as the exported model still works

--- a/docs/workloads/batch/predictors.md
+++ b/docs/workloads/batch/predictors.md
@@ -90,7 +90,7 @@ class PythonPredictor:
 
 ## TensorFlow Predictor
 
-**Uses TensorFlow version 2.4.1 by default**
+**Uses TensorFlow version 2.3.0 by default**
 
 ### Interface
 

--- a/docs/workloads/realtime/predictors.md
+++ b/docs/workloads/realtime/predictors.md
@@ -131,7 +131,7 @@ Your `predictor` method can return different types of objects such as `JSON`-par
 
 ## TensorFlow Predictor
 
-**Uses TensorFlow version 2.4.1 by default**
+**Uses TensorFlow version 2.3.0 by default**
 
 ### Interface
 

--- a/images/tensorflow-predictor/Dockerfile
+++ b/images/tensorflow-predictor/Dockerfile
@@ -48,8 +48,8 @@ COPY pkg/cortex/serve/cortex_internal.requirements.txt /src/cortex/serve/cortex_
 RUN pip install --no-cache-dir \
     -r /src/cortex/serve/serve.requirements.txt \
     -r /src/cortex/serve/cortex_internal.requirements.txt \
-    tensorflow-cpu==2.4.1 \
-    tensorflow-serving-api==2.4.1
+    tensorflow-cpu==2.3.0 \
+    tensorflow-serving-api==2.3.0
 
 COPY pkg/cortex/serve/init/install-core-dependencies.sh /usr/local/cortex/install-core-dependencies.sh
 RUN chmod +x /usr/local/cortex/install-core-dependencies.sh

--- a/images/tensorflow-serving-cpu/Dockerfile
+++ b/images/tensorflow-serving-cpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/serving:2.4.1
+FROM tensorflow/serving:2.3.0
 
 RUN apt-get update -qq && apt-get install -y -q \
     curl \

--- a/images/tensorflow-serving-gpu/Dockerfile
+++ b/images/tensorflow-serving-gpu/Dockerfile
@@ -1,9 +1,8 @@
-FROM tensorflow/serving:2.4.0-gpu
+FROM tensorflow/serving:2.3.0-gpu
 
-# https://www.tensorflow.org/install/gpu
 RUN apt-get update -qq && apt-get install -y --no-install-recommends -q \
-        libnvinfer7=7.1.3-1+cuda11.0 \
-        libnvinfer-plugin7=7.1.3-1+cuda11.0 \
+        libnvinfer6=6.0.1-1+cuda10.1 \
+        libnvinfer-plugin6=6.0.1-1+cuda10.1 \
         curl \
     && apt-get clean -qq && rm -rf /var/lib/apt/lists/*
 

--- a/pkg/cortex/serve/init/install-core-dependencies.sh
+++ b/pkg/cortex/serve/init/install-core-dependencies.sh
@@ -30,8 +30,8 @@ fi
 if [ "${CORTEX_IMAGE_TYPE}" = "tensorflow-predictor" ]; then
     if ! module_exists "tensorflow" || ! module_exists "tensorflow_serving"; then
         pip install --no-cache-dir -U \
-            tensorflow-cpu==2.4.1 \
-            tensorflow-serving-api==2.4.1
+            tensorflow-cpu==2.3.0 \
+            tensorflow-serving-api==2.3.0
     fi
 elif [ "${CORTEX_IMAGE_TYPE}" = "onnx-predictor-cpu" ] && ! module_exists "onnxruntime"; then
     pip install --no-cache-dir -U \

--- a/test/apis/keras/document-denoiser/requirements.txt
+++ b/test/apis/keras/document-denoiser/requirements.txt
@@ -3,4 +3,4 @@ requests==2.22.0
 opencv-python==4.1.2.30
 keras==2.3.1
 h5py==2.10.0
-tensorflow-cpu==2.4.1
+tensorflow-cpu==2.3.0


### PR DESCRIPTION
Rollback version update until https://github.com/tensorflow/serving/issues/1813 gets fixed

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [x] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex-labs.gitbook.io/staging/-MOmCGMADSRNQahK3Kox/) after merging)

