### PR TITLE
Add support for TrafficSplitter in GCP

### DIFF
--- a/pkg/operator/resources/resources.go
+++ b/pkg/operator/resources/resources.go
@@ -165,7 +165,7 @@ func UpdateAPI(apiConfig *userconfig.API, projectID string, force bool) (*schema
 	case userconfig.TaskAPIKind:
 		api, msg, err = taskapi.UpdateAPI(apiConfig, projectID)
 	case userconfig.TrafficSplitterKind:
-		api, msg, err = trafficsplitter.UpdateAPI(apiConfig, force)
+		api, msg, err = trafficsplitter.UpdateAPI(apiConfig)
 	default:
 		return nil, "", ErrorOperationIsOnlySupportedForKind(
 			*deployedResource, userconfig.RealtimeAPIKind,
@@ -275,7 +275,7 @@ func patchAPI(apiConfig *userconfig.API, force bool) (*spec.API, string, error) 
 	case userconfig.TaskAPIKind:
 		return taskapi.UpdateAPI(apiConfig, prevAPISpec.ProjectID)
 	default:
-		return trafficsplitter.UpdateAPI(apiConfig, force)
+		return trafficsplitter.UpdateAPI(apiConfig)
 	}
 }
 

--- a/pkg/types/spec/validations.go
+++ b/pkg/types/spec/validations.go
@@ -675,10 +675,12 @@ func ExtractAPIConfigs(
 			return nil, errors.Append(err, fmt.Sprintf("\n\napi configuration schema can be found at https://docs.cortex.dev/v/%s/", consts.CortexVersionMinor))
 		}
 
-		if resourceStruct.Kind == userconfig.BatchAPIKind ||
-			resourceStruct.Kind == userconfig.TrafficSplitterKind {
+		if resourceStruct.Kind == userconfig.BatchAPIKind {
 			if provider == types.GCPProviderType {
-				return nil, errors.Wrap(ErrorKindIsNotSupportedByProvider(resourceStruct.Kind, provider), userconfig.IdentifyAPI(configFileName, resourceStruct.Name, resourceStruct.Kind, i))
+				return nil, errors.Wrap(
+					ErrorKindIsNotSupportedByProvider(resourceStruct.Kind, provider),
+					userconfig.IdentifyAPI(configFileName, resourceStruct.Name, resourceStruct.Kind, i),
+				)
 			}
 		}
 


### PR DESCRIPTION
closes #1660 

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

