### PR TITLE
Create .cortex dir if not present in Python Client

### DIFF
--- a/pkg/cortex/client/cortex/telemetry.py
+++ b/pkg/cortex/client/cortex/telemetry.py
@@ -83,6 +83,7 @@ def _create_default_scope(optional_tags: dict = {}) -> sentry_sdk.Scope:
     user_id = None
     client_id_file_path = pathlib.Path.home() / ".cortex" / "client-id.txt"
     if not client_id_file_path.is_file():
+        client_id_file_path.parent.mkdir(parents=True, exist_ok=True)
         client_id_file_path.write_text(str(uuid4()))
     user_id = client_id_file_path.read_text()
 


### PR DESCRIPTION
If the `~/.cortex` dir doesn't exist beforehand and a cluster-up/down is initiated using the python client installation (still using the binary), that will result in a `FileNotFound` error:

```
# example error from https://app.circleci.com/pipelines/github/cortexlabs/cortex/8642/workflows/e8042290-c5f1-4c8a-a278-aac2029056ec/jobs/11332
FileNotFoundError: [Errno 2] No such file or directory: '/home/circleci/.cortex/client-id.txt'
```

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
