### PR TITLE
Track UserExceptions in Python

### DIFF
--- a/pkg/cortex/serve/cortex_internal/lib/api/predictor.py
+++ b/pkg/cortex/serve/cortex_internal/lib/api/predictor.py
@@ -243,6 +243,8 @@ class Predictor:
         Initialize predictor class as provided by the user.
 
         job_spec is a dictionary when the "kind" of the API is set to "BatchAPI". Otherwise, it's None.
+
+        Can raise UserRuntimeException/UserException/CortexException.
         """
 
         # build args
@@ -306,6 +308,7 @@ class Predictor:
         return initialized_impl
 
     def class_impl(self, project_dir):
+        """Can only raise UserException/CortexException exceptions"""
         if self.type in [TensorFlowPredictorType, TensorFlowNeuronPredictorType]:
             target_class_name = "TensorFlowPredictor"
             validations = TENSORFLOW_CLASS_VALIDATION
@@ -322,7 +325,7 @@ class Predictor:
             predictor_class = self._get_class_impl(
                 "cortex_predictor", os.path.join(project_dir, self.path), target_class_name
             )
-        except (UserException, Exception) as e:
+        except Exception as e:
             e.wrap("error in " + self.path)
             raise
 
@@ -330,12 +333,13 @@ class Predictor:
             validate_class_impl(predictor_class, validations)
             if self.type == PythonPredictorType:
                 validate_python_predictor_with_models(predictor_class, self.api_spec)
-        except (UserException, Exception) as e:
+        except Exception as e:
             e.wrap("error in " + self.path)
             raise
         return predictor_class
 
     def _get_class_impl(self, module_name, impl_path, target_class_name):
+        """Can only raise UserException exception"""
         if impl_path.endswith(".pickle"):
             try:
                 with open(impl_path, "rb") as pickle_file:

--- a/pkg/cortex/serve/cortex_internal/lib/telemetry.py
+++ b/pkg/cortex/serve/cortex_internal/lib/telemetry.py
@@ -73,7 +73,7 @@ def init_sentry(
         dsn=dsn,
         environment=environment,
         release=release,
-        ignore_errors=[cexp.UserException, cexp.UserRuntimeException],
+        ignore_errors=[cexp.UserRuntimeException],
         attach_stacktrace=True,
         integrations=[
             LoggingIntegration(event_level=None, level=None),

--- a/pkg/cortex/serve/cortex_internal/serve/serve.py
+++ b/pkg/cortex/serve/cortex_internal/serve/serve.py
@@ -333,7 +333,7 @@ def start_fn():
         predict_route = "/predict"
         local_cache["predict_route"] = predict_route
 
-    except (UserRuntimeException, Exception) as err:
+    except Exception as err:
         if not isinstance(err, UserRuntimeException):
             capture_exception(err)
         logger.exception("failed to start api")

--- a/pkg/cortex/serve/start/batch.py
+++ b/pkg/cortex/serve/start/batch.py
@@ -227,7 +227,7 @@ def handle_batch_message(message):
         api.post_metrics(
             [success_counter_metric(), time_per_batch_metric(time.time() - start_time)]
         )
-    except (UserRuntimeException, Exception) as err:
+    except Exception as err:
         if not isinstance(err, UserRuntimeException):
             capture_exception(err)
 
@@ -285,7 +285,7 @@ def handle_on_job_complete(message):
                     break
                 should_run_on_job_complete = True
             time.sleep(10)  # verify that the queue is empty one more time
-    except (UserRuntimeException, Exception) as err:
+    except Exception as err:
         raise type(err)("failed to handle on_job_complete") from err
     finally:
         with receipt_handle_mutex:
@@ -339,7 +339,7 @@ def start():
             metrics_client=metrics_client,
             job_spec=job_spec,
         )
-    except (UserException, UserRuntimeException) as err:
+    except UserRuntimeException as err:
         err.wrap(f"failed to start job {job_spec['job_id']}")
         logger.error(str(err), exc_info=True)
         sys.exit(1)


### PR DESCRIPTION
`UserExceptions` exceptions can be tracked in sentry.io by just typing in the name of the exception. No need for a tag.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
