### PR TITLE
Increase buffer size for logs to address unexpected log stream termination

### DIFF
--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -116,7 +116,7 @@ func startKubectlProcess(podName string, cancelListener chan struct{}, socket *w
 
 func pumpStdout(socket *websocket.Conn, reader io.Reader) {
 	// it seems like if the buffer is maxed out with no ending token, the scanner just exits.
-	// increase the buffer used by the scanner to accomodate larger log lines (a common issue when printing progress)
+	// increase the buffer used by the scanner to accomomdate larger log lines (a common issue when printing progress)
 	p := make([]byte, 1024*1024)
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(p, 1024*1024)

--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -116,7 +116,7 @@ func startKubectlProcess(podName string, cancelListener chan struct{}, socket *w
 
 func pumpStdout(socket *websocket.Conn, reader io.Reader) {
 	// it seems like if the buffer is maxed out with no ending token, the scanner just exits.
-	// increase the buffer used by the scanner to accomodote larger log lines (a common issue when printing progress)
+	// increase the buffer used by the scanner to accomodate larger log lines (a common issue when printing progress)
 	p := make([]byte, 1024*1024)
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(p, 1024*1024)

--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -115,7 +115,8 @@ func startKubectlProcess(podName string, cancelListener chan struct{}, socket *w
 }
 
 func pumpStdout(socket *websocket.Conn, reader io.Reader) {
-	// increase the buffer used by the scanner to accomadate large log lines such as inline progress printing
+	// it seems like if the buffer is maxed out with no ending token, the scanner just exits.
+	// increase the buffer used by the scanner to accomadote larger log lines (a common issue when printing progress)
 	p := make([]byte, 1024*1024)
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(p, 1024*1024)

--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -116,7 +116,7 @@ func startKubectlProcess(podName string, cancelListener chan struct{}, socket *w
 
 func pumpStdout(socket *websocket.Conn, reader io.Reader) {
 	// it seems like if the buffer is maxed out with no ending token, the scanner just exits.
-	// increase the buffer used by the scanner to accomomdate larger log lines (a common issue when printing progress)
+	// increase the buffer used by the scanner to accommodate larger log lines (a common issue when printing progress)
 	p := make([]byte, 1024*1024)
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(p, 1024*1024)

--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -116,7 +116,7 @@ func startKubectlProcess(podName string, cancelListener chan struct{}, socket *w
 
 func pumpStdout(socket *websocket.Conn, reader io.Reader) {
 	// it seems like if the buffer is maxed out with no ending token, the scanner just exits.
-	// increase the buffer used by the scanner to accomadote larger log lines (a common issue when printing progress)
+	// increase the buffer used by the scanner to accomodote larger log lines (a common issue when printing progress)
 	p := make([]byte, 1024*1024)
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(p, 1024*1024)

--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -115,7 +115,10 @@ func startKubectlProcess(podName string, cancelListener chan struct{}, socket *w
 }
 
 func pumpStdout(socket *websocket.Conn, reader io.Reader) {
+	// increase the buffer used by the scanner to accomadate large log lines such as inline progress printing
+	p := make([]byte, 1024*1024)
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(p, 1024*1024)
 	for scanner.Scan() {
 		logBytes := scanner.Bytes()
 		var message jsonMessage


### PR DESCRIPTION
---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
