### PR TITLE
Temporarily lock torch to 1.7 for pytorch text-generator gpu tests

### DIFF
--- a/test/apis/pytorch/text-generator/requirements.txt
+++ b/test/apis/pytorch/text-generator/requirements.txt
@@ -1,2 +1,2 @@
-torch
+torch==1.7.*
 transformers==3.0.*


### PR DESCRIPTION
Torch 1.8.0 came out recently and certain operations don't seem to be supported for CUDA 10.2 cudnn 7/8 on a Tesla T4. It appears to not work for cuda 10.1 cudnn 7 as well.

Torch 1.7 seems to be working as expected. Temporarily set the Torch version to 1.7 till issues on Torch 1.8 are resolved. Here is a related issue: https://github.com/pytorch/pytorch/issues/53336.

---

checklist:

- [X] run `make test` and `make lint`
- [X] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
