### PR TITLE
Change cgroupDriver from systemd to cgroupfs

### DIFF
--- a/manager/generate_eks.py
+++ b/manager/generate_eks.py
@@ -107,6 +107,9 @@ def apply_spot_settings(nodegroup, config):
 
 def apply_gpu_settings(nodegroup):
     gpu_settings = {
+        "preBootstrapCommands": [
+            "sed -i 's/cgroupDriver:.*/cgroupDriver: cgroupfs/' /etc/eksctl/kubelet.yaml"
+        ],
         "tags": {
             "k8s.io/cluster-autoscaler/node-template/label/nvidia.com/gpu": "true",
             "k8s.io/cluster-autoscaler/node-template/taint/dedicated": "nvidia.com/gpu=true",


### PR DESCRIPTION
GPU nodes are not joining the cluster. AWS changed the AMI for GPUs on [March 5th](https://console.aws.amazon.com/systems-manager/parameters/%252Faws%252Fservice%252Feks%252Foptimized-ami%252F1.18%252Famazon-linux-2-gpu%252Frecommended%252Fimage_id/description?region=us-west-2) which coincide with our failed GPU tests on AWS.

It sounds like the cgroupDriver value for CPU based AMIs seem to be cgroupfs but for GPU AMIs they seem to be systemd. This commit changes cgroupDriver to cgroupfs.

This appears to be a workaround. More information about the issue and the possible workarounds are described in this comment: https://github.com/weaveworks/eksctl/issues/3005#issuecomment-752955957.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ ] update examples
- [ ] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex-labs.gitbook.io/staging/-MOmCGMADSRNQahK3Kox/) after merging)
- [ ] cherry-pick into release branches if applicable
- [ ] alert the dev team if the dev environment changed
