### PR TITLE
Fix Python client not respecting CORTEX_CLI_CONFIG_DIR environment variable for client-id.txt

### DIFF
--- a/pkg/cortex/client/cortex/client.py
+++ b/pkg/cortex/client/cortex/client.py
@@ -33,13 +33,6 @@ from cortex.consts import EXPECTED_PYTHON_VERSION
 from cortex import util
 
 
-def cli_config_dir() -> Path:
-    cli_config_dir = os.environ.get("CORTEX_CLI_CONFIG_DIR", "")
-    if cli_config_dir == "":
-        return Path.home() / ".cortex"
-    return Path(cli_config_dir).expanduser().resolve()
-
-
 class Client:
     @sentry_wrapper
     def __init__(self, env: dict):
@@ -129,7 +122,7 @@ class Client:
         if api_spec.get("name") is None:
             raise ValueError("`api_spec` must have the `name` key set")
 
-        project_dir = cli_config_dir() / "deployments" / api_spec["name"]
+        project_dir = util.cli_config_dir() / "deployments" / api_spec["name"]
 
         if project_dir.exists():
             shutil.rmtree(str(project_dir))
@@ -367,7 +360,7 @@ class Client:
             force: Override an already in-progress API update.
         """
 
-        cortex_yaml_file = cli_config_dir() / "deployments" / f"cortex-{str(uuid.uuid4())}.yaml"
+        cortex_yaml_file = util.cli_config_dir() / "deployments" / f"cortex-{str(uuid.uuid4())}.yaml"
         with util.open_temporarily(cortex_yaml_file, "w") as f:
             yaml.dump([api_spec], f)
             args = ["patch", cortex_yaml_file, "--env", self.env_name, "-o", "json"]

--- a/pkg/cortex/client/cortex/telemetry.py
+++ b/pkg/cortex/client/cortex/telemetry.py
@@ -28,6 +28,7 @@ from cortex.consts import (
     CORTEX_TELEMETRY_SENTRY_DSN,
     CORTEX_TELEMETRY_SENTRY_ENVIRONMENT,
 )
+from cortex import util
 
 
 def _sentry_client(
@@ -81,7 +82,7 @@ def _create_default_scope(optional_tags: dict = {}) -> sentry_sdk.Scope:
     scope = sentry_sdk.Scope()
 
     user_id = None
-    client_id_file_path = pathlib.Path.home() / ".cortex" / "client-id.txt"
+    client_id_file_path = util.cli_config_dir() / "client-id.txt"
     if not client_id_file_path.is_file():
         client_id_file_path.parent.mkdir(parents=True, exist_ok=True)
         client_id_file_path.write_text(str(uuid4()))

--- a/pkg/cortex/client/cortex/util.py
+++ b/pkg/cortex/client/cortex/util.py
@@ -18,6 +18,13 @@ from pathlib import Path
 import shutil
 
 
+def cli_config_dir() -> Path:
+    cli_config_dir = os.environ.get("CORTEX_CLI_CONFIG_DIR", "")
+    if cli_config_dir == "":
+        return Path.home() / ".cortex"
+    return Path(cli_config_dir).expanduser().resolve()
+
+
 @contextmanager
 def open_temporarily(path, mode):
     Path(path).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Currently, the python client does not respect the `CORTEX_CLI_CONFIG_DIR` environment variable when locating `"client-id.txt"` while creating the default scope for sentry. This results in two `"client-id.txt"` files with different uuids when this environment variable is set - one created by the cortex CLI in the specified directory and the other created by the python client in `~/.cortex`. This PR fixes this by using `cli_config_dir()` to locate `client-id.txt` when creating the sentry default scope.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ ] update examples
- [ ] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex-labs.gitbook.io/staging/-MOmCGMADSRNQahK3Kox/) after merging)
- [ ] cherry-pick into release branches if applicable
- [ ] alert the dev team if the dev environment changed
