### PR TITLE
Fix preemptible typo in cluster-autoscaler template

### DIFF
--- a/manager/manifests/cluster-autoscaler.yaml.j2
+++ b/manager/manifests/cluster-autoscaler.yaml.j2
@@ -205,7 +205,7 @@ spec:
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ config['cluster_name'] }}
             {% else %}
             {% for np in config['node_pools'] %}
-            {% if np['preemptile'] %}
+            {% if np['preemptible'] %}
             - --node-group-auto-discovery=mig:namePrefix=gke-{{ config['cluster_name'] }}-cx-ws-{{ np['name'] }},min={{ np['min_instances'] }},max={{ np['max_instances'] }}
             {% else %}
             - --node-group-auto-discovery=mig:namePrefix=gke-{{ config['cluster_name'] }}-cx-wd-{{ np['name'] }},min={{ np['min_instances'] }},max={{ np['max_instances'] }}


### PR DESCRIPTION
---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

