### PR TITLE
Fix async e2e tests flakiness

### DIFF
--- a/test/e2e/tests/aws/test_async.py
+++ b/test/e2e/tests/aws/test_async.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Any
+from typing import Dict
 
 import cortex as cx
 import pytest
@@ -20,19 +20,18 @@ import pytest
 import e2e.tests
 
 TEST_APIS = [
-    {"name": "async/iris-classifier", "poll_retries": 10, "poll_sleep_time": 1},
-    {"name": "async/tensorflow", "poll_retries": 10, "poll_sleep_time": 1},
-    {"name": "async/onnx", "poll_retries": 10, "poll_sleep_time": 1},
+    "async/iris-classifier",
+    "async/tensorflow",
+    "async/onnx",
 ]
 
 
 @pytest.mark.usefixtures("client")
-@pytest.mark.parametrize("api", TEST_APIS, ids=[api["name"] for api in TEST_APIS])
-def test_async_api(config: Dict, client: cx.Client, api: Dict[str, Any]):
+@pytest.mark.parametrize("api", TEST_APIS)
+def test_async_api(config: Dict, client: cx.Client, api: str):
     e2e.tests.test_async_api(
         client=client,
-        api=api["name"],
+        api=api,
         deploy_timeout=config["global"]["async_deploy_timeout"],
-        poll_retries=api["poll_retries"],
-        poll_sleep_seconds=api["poll_sleep_time"],
+        poll_retries=config["global"]["async_workload_timeout"],
     )

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -84,6 +84,7 @@ def pytest_configure(config):
             "batch_deploy_timeout": int(os.environ.get("CORTEX_TEST_BATCH_DEPLOY_TIMEOUT", 30)),
             "batch_job_timeout": int(os.environ.get("CORTEX_TEST_BATCH_JOB_TIMEOUT", 200)),
             "async_deploy_timeout": int(os.environ.get("CORTEX_TEST_ASYNC_DEPLOY_TIMEOUT", 30)),
+            "async_workload_timeout": int(os.environ.get("CORTEX_TEST_ASYNC_WORKLOAD_TIMEOUT", 30)),
             "task_deploy_timeout": int(os.environ.get("CORTEX_TEST_TASK_DEPLOY_TIMEOUT", 30)),
             "task_job_timeout": int(os.environ.get("CORTEX_TEST_TASK_JOB_TIMEOUT", 200)),
             "skip_gpus": config.getoption("--skip-gpus"),


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

