### PR TITLE
Disallow the use of post_predict for grpc protocol

### DIFF
--- a/pkg/cortex/serve/cortex_internal/lib/api/validations.py
+++ b/pkg/cortex/serve/cortex_internal/lib/api/validations.py
@@ -171,3 +171,9 @@ def validate_predictor_with_grpc(impl, api_spec):
             f'invalid signature for method "predict"',
             f'{util.string_plural_with_s("argument", len(disallowed_params))} {util.and_list_with_quotes(disallowed_params)} cannot be used when the grpc protocol is enabled',
         )
+
+    if getattr(impl, "post_predict", None):
+        raise UserException(
+            f"class {target_class_name}",
+            f"post_predict method is not supported when the grpc protocol is enabled",
+        )


### PR DESCRIPTION
checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
