### PR TITLE
Add CPU limits to fluent-bit daemon set

### DIFF
--- a/manager/manifests/fluent-bit.yaml.j2
+++ b/manager/manifests/fluent-bit.yaml.j2
@@ -202,6 +202,7 @@ spec:
               cpu: 100m
               memory: 150Mi
             limits:
+              cpu: 150m
               memory: 150Mi
           ports:
             - containerPort: 2020


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

