### PR TITLE
Fix number of API replicas shown in `cortex cluster info` cmd

### DIFF
--- a/pkg/operator/endpoints/info.go
+++ b/pkg/operator/endpoints/info.go
@@ -109,6 +109,7 @@ func getNodeInfos() ([]schema.NodeInfo, int, error) {
 		pod := pods[i]
 
 		_, isAPIPod := pod.Labels["apiName"]
+		asyncDeploymentType, isAsyncPod := pod.Labels["cortex.dev/async"]
 
 		if pod.Spec.NodeName == "" && isAPIPod {
 			numPendingReplicas++
@@ -120,7 +121,7 @@ func getNodeInfos() ([]schema.NodeInfo, int, error) {
 			continue
 		}
 
-		if isAPIPod {
+		if isAPIPod && (!isAsyncPod || asyncDeploymentType != "gateway") {
 			node.NumReplicas++
 		}
 


### PR DESCRIPTION
Fixes  #2129.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
