### PR TITLE
Change eksctl filter prefix regex to more a more permissive one

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -70,7 +70,7 @@ var (
 	_flagClusterDownKeepVolumes   bool
 )
 
-var _eksctlPrefixRegex = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[.+] {2}`)
+var _eksctlPrefixRegex = regexp.MustCompile(`.+ \[.+] {2}`)
 
 func clusterInit() {
 	_clusterUpCmd.Flags().SortFlags = false

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -70,7 +70,7 @@ var (
 	_flagClusterDownKeepVolumes   bool
 )
 
-var _eksctlPrefixRegex = regexp.MustCompile(`.+ \[.+] {2}`)
+var _eksctlPrefixRegex = regexp.MustCompile(`^.*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[.+] {2}`)
 
 func clusterInit() {
 	_clusterUpCmd.Flags().SortFlags = false

--- a/pkg/lib/strings/operations_test.go
+++ b/pkg/lib/strings/operations_test.go
@@ -75,7 +75,7 @@ func TestRemoveDuplicates(t *testing.T) {
 		},
 		{
 			name:        "eksctl",
-			prefixRegex: regexp.MustCompile(`.+ \[.+] {2}`),
+			prefixRegex: regexp.MustCompile(`^.*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[.+] {2}`),
 			input: []string{
 				"2021-03-26 00:03:50 [ℹ]  eksctl version 0.40.0",
 				"2021-03-26 00:03:50 [ℹ]  using region us-east-1",

--- a/pkg/lib/strings/operations_test.go
+++ b/pkg/lib/strings/operations_test.go
@@ -75,7 +75,7 @@ func TestRemoveDuplicates(t *testing.T) {
 		},
 		{
 			name:        "eksctl",
-			prefixRegex: regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[.+] {2}`),
+			prefixRegex: regexp.MustCompile(`.+ \[.+] {2}`),
 			input: []string{
 				"2021-03-26 00:03:50 [ℹ]  eksctl version 0.40.0",
 				"2021-03-26 00:03:50 [ℹ]  using region us-east-1",


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)