### PR TITLE
Import pytorch neuron package for Inferentia

### DIFF
--- a/test/apis/batch/inferentia/handler.py
+++ b/test/apis/batch/inferentia/handler.py
@@ -46,6 +46,7 @@ class Handler:
             self.model.load_state_dict(torch.load(model_name))
             self.model.eval()
         elif config["device"] == "inf":
+            import torch_neuron
 
             self.model = torch.jit.load(model_name)
         else:


### PR DESCRIPTION
This is supposed to fix the following error:

```
error: failed to start job 69825fce8a68c1bb: handler.py: __init__: 
Unknown builtin op: neuron::forward_1.
Could not find any similar ops to neuron::forward_1. This op may not exist or may not be currently supported in TorchScript.
:
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/torch_neuron/decorators.py(249): forward
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/torch/nn/modules/module.py(525): _slow_forward
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/torch/nn/modules/module.py(539): __call__
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/torch/jit/__init__.py(997): trace_module
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/torch/jit/__init__.py(858): trace
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/torch_neuron/decorators.py(263): trace
<ipython-input-3-7cb92c86fd43>(3): <module>
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/IPython/core/interactiveshell.py(3331): run_code
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/IPython/core/interactiveshell.py(3254): run_ast_nodes
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/IPython/core/interactiveshell.py(3063): run_cell_async
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/IPython/core/async_helpers.py(68): _pseudo_sync_runner
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/IPython/core/interactiveshell.py(2886): _run_cell
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/IPython/core/interactiveshell.py(2858): run_cell
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/ipykernel/zmqshell.py(536): run_cell
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/ipykernel/ipkernel.py(300): do_execute
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/gen.py(209): wrapper
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/ipykernel/kernelbase.py(545): execute_request
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/gen.py(209): wrapper
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/ipykernel/kernelbase.py(268): dispatch_shell
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/gen.py(209): wrapper
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/ipykernel/kernelbase.py(365): process_one
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/gen.py(748): run
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/gen.py(787): inner
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/ioloop.py(743): _run_callback
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/ioloop.py(690): <lambda>
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/asyncio/events.py(145): _run
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/asyncio/base_events.py(1451): _run_once
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/asyncio/base_events.py(438): run_forever
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/tornado/platform/asyncio.py(149): start
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/ipykernel/kernelapp.py(583): start
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/traitlets/config/application.py(664): launch_instance
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/site-packages/ipykernel_launcher.py(16): <module>
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/runpy.py(85): _run_code
/home/robert/.miniconda3/envs/py36-neuron-2/lib/python3.6/runpy.py(193): _run_module_as_main
Serialized   File "code/__torch__/torch_neuron/decorators.py", line 7
  def forward(self: __torch__.torch_neuron.decorators.NeuronModule,
    argument_1: Tensor) -> Tensor:
    _0 = ops.neuron.forward_1([argument_1], CONSTANTS.c0, CONSTANTS.c1, CONSTANTS.c2)
'
'
```

~~I haven't tested it, but I'm pretty sure this is the problem.~~ `torch_neuron` needs to be imported before the model gets loaded even if the package isn't apparently used anywhere (but in reality it is used).

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
