### PR TITLE
Use 405 status code for un-implemented methods for the Realtime API

### DIFF
--- a/python/serve/cortex_internal/serve/serve.py
+++ b/python/serve/cortex_internal/serve/serve.py
@@ -187,7 +187,7 @@ def handle(request: Request):
     verb = request.method.lower()
     handle_fn_args = local_cache["handle_fn_args"]
     if verb not in handle_fn_args:
-        return Response(status_code=405, content=f"`handle_{verb}` method not implemented")
+        return Response(status_code=405, content="method not implemented")
 
     handler_impl = local_cache["handler_impl"]
     dynamic_batcher = None

--- a/python/serve/cortex_internal/serve/serve.py
+++ b/python/serve/cortex_internal/serve/serve.py
@@ -187,7 +187,7 @@ def handle(request: Request):
     verb = request.method.lower()
     handle_fn_args = local_cache["handle_fn_args"]
     if verb not in handle_fn_args:
-        raise UserRuntimeException(f"`handle_{verb}` method is not implemented")
+        return Response(status_code=405, content=f"`handle_{verb}` method not allowed")
 
     handler_impl = local_cache["handler_impl"]
     dynamic_batcher = None

--- a/python/serve/cortex_internal/serve/serve.py
+++ b/python/serve/cortex_internal/serve/serve.py
@@ -187,7 +187,7 @@ def handle(request: Request):
     verb = request.method.lower()
     handle_fn_args = local_cache["handle_fn_args"]
     if verb not in handle_fn_args:
-        return Response(status_code=405, content=f"`handle_{verb}` method not allowed")
+        return Response(status_code=405, content=f"`handle_{verb}` method not implemented")
 
     handler_impl = local_cache["handler_impl"]
     dynamic_batcher = None


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)