### PR TITLE
Remove the omitempty tag for BatchesInQueue field

### DIFF
--- a/pkg/types/status/job_status.go
+++ b/pkg/types/status/job_status.go
@@ -27,7 +27,7 @@ type BatchJobStatus struct {
 	spec.BatchJob
 	Status         JobCode               `json:"status"`
 	EndTime        *time.Time            `json:"end_time,omitempty"`
-	BatchesInQueue int                   `json:"batches_in_queue,omitempty"`
+	BatchesInQueue int                   `json:"batches_in_queue"`
 	BatchMetrics   *metrics.BatchMetrics `json:"batch_metrics,omitempty"`
 	WorkerCounts   *WorkerCounts         `json:"worker_counts,omitempty"`
 }


### PR DESCRIPTION
This is to fix the following error (from this build https://app.circleci.com/pipelines/github/cortexlabs/cortex/9975/workflows/baf607ea-73ae-4066-be0f-da89a5586909/jobs/12944) that can occur for a batch API:

```
            # assert jobs
            printer("checking the jobs' responses")
            for job_spec in job_specs:
                job_id: str = job_spec["job_id"]
                job_status = requests.get(f"{api_endpoint}?jobID={job_id}").json()["job_status"]
    
                assert (
>                   job_status["batches_in_queue"] == 0
                ), f"there are still batches in queue ({job_status['batches_in_queue']}) for job ID {job_id}"
E               KeyError: 'batches_in_queue'
```

So if there are no batches in the queue, then `batches_in_queue` field won't be present in the batch response. And that's what the `KeyError: 'batches_in_queue'` error is about.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)