### PR TITLE
Use `cortex-nightly*` bucket for batch artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
     docker:
       - image: circleci/python:3.6
     environment:
-      CORTEX_TEST_BATCH_S3_PATH: s3://cortex-dev-nightly/test/jobs
+      CORTEX_TEST_BATCH_S3_PATH: s3://cortex-nightly-artifacts/test/jobs
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Fixes `botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied` error.
