### PR TITLE
Fix make operator-local command

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cortexlabs/cortex/pkg/consts"
 	batch "github.com/cortexlabs/cortex/pkg/crds/apis/batch/v1alpha1"
 	"github.com/cortexlabs/cortex/pkg/lib/aws"
+	cr "github.com/cortexlabs/cortex/pkg/lib/configreader"
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/hash"
 	"github.com/cortexlabs/cortex/pkg/lib/k8s"
@@ -58,6 +59,20 @@ func init() {
 func InitConfigs(clusterConfig *clusterconfig.Config, operatorMetadata *clusterconfig.OperatorMetadata) {
 	ClusterConfig = clusterConfig
 	OperatorMetadata = operatorMetadata
+}
+
+func getClusterConfigFromConfigMap() (clusterconfig.Config, error) {
+	configMapData, err := K8s.GetConfigMapData("cluster-config")
+	if err != nil {
+		return clusterconfig.Config{}, err
+	}
+	clusterConfig := clusterconfig.Config{}
+	errs := cr.ParseYAMLBytes(&clusterConfig, clusterconfig.FullManagedValidation, []byte(configMapData["cluster.yaml"]))
+	if errors.FirstError(errs...) != nil {
+		return clusterconfig.Config{}, errors.FirstError(errs...)
+	}
+
+	return clusterConfig, nil
 }
 
 func Init() error {
@@ -103,6 +118,22 @@ func Init() error {
 	clusterNamespace = clusterConfig.Namespace
 	istioNamespace = clusterConfig.IstioNamespace
 
+	if K8s, err = k8s.New(clusterNamespace, OperatorMetadata.IsOperatorInCluster, nil, scheme); err != nil {
+		return err
+	}
+
+	if K8sIstio, err = k8s.New(istioNamespace, OperatorMetadata.IsOperatorInCluster, nil, scheme); err != nil {
+		return err
+	}
+
+	if !OperatorMetadata.IsOperatorInCluster {
+		cc, err := getClusterConfigFromConfigMap()
+		if err != nil {
+			return err
+		}
+		clusterConfig.Bucket = cc.Bucket
+	}
+
 	exists, err := AWS.DoesBucketExist(clusterConfig.Bucket)
 	if err != nil {
 		return err
@@ -124,14 +155,6 @@ func Init() error {
 	})
 	if err != nil {
 		fmt.Println(errors.Message(err))
-	}
-
-	if K8s, err = k8s.New(clusterNamespace, OperatorMetadata.IsOperatorInCluster, nil, scheme); err != nil {
-		return err
-	}
-
-	if K8sIstio, err = k8s.New(istioNamespace, OperatorMetadata.IsOperatorInCluster, nil, scheme); err != nil {
-		return err
 	}
 
 	prometheusURL := os.Getenv("CORTEX_PROMETHEUS_URL")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,9 +67,9 @@ func getClusterConfigFromConfigMap() (clusterconfig.Config, error) {
 		return clusterconfig.Config{}, err
 	}
 	clusterConfig := clusterconfig.Config{}
-	errs := cr.ParseYAMLBytes(&clusterConfig, clusterconfig.FullManagedValidation, []byte(configMapData["cluster.yaml"]))
-	if errors.FirstError(errs...) != nil {
-		return clusterconfig.Config{}, errors.FirstError(errs...)
+	err = cr.ParseYAMLBytes(&clusterConfig, clusterconfig.FullManagedValidation, []byte(configMapData["cluster.yaml"]))
+	if err != nil {
+		return clusterconfig.Config{}, err
 	}
 
 	return clusterConfig, nil

--- a/pkg/lib/configreader/reader.go
+++ b/pkg/lib/configreader/reader.go
@@ -1038,15 +1038,15 @@ func ParseYAMLFile(dest interface{}, validation *StructValidation, filePath stri
 	return nil
 }
 
-func ParseYAMLBytes(dest interface{}, validation *StructValidation, data []byte) []error {
+func ParseYAMLBytes(dest interface{}, validation *StructValidation, data []byte) error {
 	fileInterface, err := ReadYAMLBytes(data)
 	if err != nil {
-		return []error{err}
+		return nil
 	}
 
 	errs := Struct(dest, fileInterface, validation)
 	if errors.HasError(errs) {
-		return errs
+		return errors.FirstError(errs...)
 	}
 
 	return nil

--- a/pkg/lib/configreader/reader.go
+++ b/pkg/lib/configreader/reader.go
@@ -1038,6 +1038,20 @@ func ParseYAMLFile(dest interface{}, validation *StructValidation, filePath stri
 	return nil
 }
 
+func ParseYAMLBytes(dest interface{}, validation *StructValidation, data []byte) []error {
+	fileInterface, err := ReadYAMLBytes(data)
+	if err != nil {
+		return []error{err}
+	}
+
+	errs := Struct(dest, fileInterface, validation)
+	if errors.HasError(errs) {
+		return errs
+	}
+
+	return nil
+}
+
 func ReadYAMLFile(filePath string) (interface{}, error) {
 	fileBytes, err := files.ReadFileBytes(filePath)
 	if err != nil {


### PR DESCRIPTION
Running the `make operator-local` command is failing because the bucket is not available.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)