### PR TITLE
CaaS - fix cortex CLI

### DIFF
--- a/pkg/operator/endpoints/delete.go
+++ b/pkg/operator/endpoints/delete.go
@@ -32,5 +32,5 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, err)
 		return
 	}
-	respond(w, response)
+	respond(w, r, response)
 }

--- a/pkg/operator/endpoints/delete.go
+++ b/pkg/operator/endpoints/delete.go
@@ -32,5 +32,5 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, err)
 		return
 	}
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }

--- a/pkg/operator/endpoints/deploy.go
+++ b/pkg/operator/endpoints/deploy.go
@@ -48,5 +48,5 @@ func Deploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, response)
+	respond(w, r, response)
 }

--- a/pkg/operator/endpoints/deploy.go
+++ b/pkg/operator/endpoints/deploy.go
@@ -48,5 +48,5 @@ func Deploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }

--- a/pkg/operator/endpoints/get.go
+++ b/pkg/operator/endpoints/get.go
@@ -30,7 +30,7 @@ func GetAPIs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }
 
 func GetAPI(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +42,7 @@ func GetAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }
 
 func GetAPIByID(w http.ResponseWriter, r *http.Request) {
@@ -55,5 +55,5 @@ func GetAPIByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }

--- a/pkg/operator/endpoints/get.go
+++ b/pkg/operator/endpoints/get.go
@@ -30,7 +30,7 @@ func GetAPIs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, response)
+	respond(w, r, response)
 }
 
 func GetAPI(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +42,7 @@ func GetAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, response)
+	respond(w, r, response)
 }
 
 func GetAPIByID(w http.ResponseWriter, r *http.Request) {
@@ -55,5 +55,5 @@ func GetAPIByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, response)
+	respond(w, r, response)
 }

--- a/pkg/operator/endpoints/get_batch_job.go
+++ b/pkg/operator/endpoints/get_batch_job.go
@@ -86,5 +86,5 @@ func GetBatchJob(w http.ResponseWriter, r *http.Request) {
 		Endpoint:  parsedURL.String(),
 	}
 
-	respond(w, response)
+	respond(w, r, response)
 }

--- a/pkg/operator/endpoints/get_batch_job.go
+++ b/pkg/operator/endpoints/get_batch_job.go
@@ -86,5 +86,5 @@ func GetBatchJob(w http.ResponseWriter, r *http.Request) {
 		Endpoint:  parsedURL.String(),
 	}
 
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }

--- a/pkg/operator/endpoints/get_task_job.go
+++ b/pkg/operator/endpoints/get_task_job.go
@@ -86,5 +86,5 @@ func GetTaskJob(w http.ResponseWriter, r *http.Request) {
 		Endpoint:  parsedURL.String(),
 	}
 
-	respond(w, response)
+	respond(w, r, response)
 }

--- a/pkg/operator/endpoints/get_task_job.go
+++ b/pkg/operator/endpoints/get_task_job.go
@@ -86,5 +86,5 @@ func GetTaskJob(w http.ResponseWriter, r *http.Request) {
 		Endpoint:  parsedURL.String(),
 	}
 
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }

--- a/pkg/operator/endpoints/info.go
+++ b/pkg/operator/endpoints/info.go
@@ -48,7 +48,7 @@ func Info(w http.ResponseWriter, r *http.Request) {
 		NodeInfos:          nodeInfos,
 		NumPendingReplicas: numPendingReplicas,
 	}
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }
 
 func getNodeInfos() ([]schema.NodeInfo, int, error) {

--- a/pkg/operator/endpoints/info.go
+++ b/pkg/operator/endpoints/info.go
@@ -48,7 +48,7 @@ func Info(w http.ResponseWriter, r *http.Request) {
 		NodeInfos:          nodeInfos,
 		NumPendingReplicas: numPendingReplicas,
 	}
-	respond(w, response)
+	respond(w, r, response)
 }
 
 func getNodeInfos() ([]schema.NodeInfo, int, error) {

--- a/pkg/operator/endpoints/refresh.go
+++ b/pkg/operator/endpoints/refresh.go
@@ -37,5 +37,5 @@ func Refresh(w http.ResponseWriter, r *http.Request) {
 	response := schema.RefreshResponse{
 		Message: msg,
 	}
-	respond(w, r, response)
+	respondJSON(w, r, response)
 }

--- a/pkg/operator/endpoints/refresh.go
+++ b/pkg/operator/endpoints/refresh.go
@@ -37,5 +37,5 @@ func Refresh(w http.ResponseWriter, r *http.Request) {
 	response := schema.RefreshResponse{
 		Message: msg,
 	}
-	respond(w, response)
+	respond(w, r, response)
 }

--- a/pkg/operator/endpoints/respond.go
+++ b/pkg/operator/endpoints/respond.go
@@ -28,16 +28,12 @@ import (
 
 var operatorLogger = logging.GetLogger()
 
-func respond(w http.ResponseWriter, response interface{}) {
+func respond(w http.ResponseWriter, r *http.Request, response interface{}) {
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		respondError(w, r, errors.Wrap(err, "failed to encode response"))
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(response)
-}
-
-func respondPlainText(w http.ResponseWriter, response string) {
-	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(response))
 }
 
 func respondError(w http.ResponseWriter, r *http.Request, err error, strs ...string) {

--- a/pkg/operator/endpoints/respond.go
+++ b/pkg/operator/endpoints/respond.go
@@ -28,7 +28,7 @@ import (
 
 var operatorLogger = logging.GetLogger()
 
-func respond(w http.ResponseWriter, r *http.Request, response interface{}) {
+func respondJSON(w http.ResponseWriter, r *http.Request, response interface{}) {
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		respondError(w, r, errors.Wrap(err, "failed to encode response"))
 	}

--- a/pkg/operator/endpoints/stop_batch_job.go
+++ b/pkg/operator/endpoints/stop_batch_job.go
@@ -46,7 +46,7 @@ func StopBatchJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, schema.DeleteResponse{
+	respond(w, r, schema.DeleteResponse{
 		Message: fmt.Sprintf("stopped job %s", jobID),
 	})
 }

--- a/pkg/operator/endpoints/stop_batch_job.go
+++ b/pkg/operator/endpoints/stop_batch_job.go
@@ -46,7 +46,7 @@ func StopBatchJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, schema.DeleteResponse{
+	respondJSON(w, r, schema.DeleteResponse{
 		Message: fmt.Sprintf("stopped job %s", jobID),
 	})
 }

--- a/pkg/operator/endpoints/stop_task_job.go
+++ b/pkg/operator/endpoints/stop_task_job.go
@@ -46,7 +46,7 @@ func StopTaskJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, schema.DeleteResponse{
+	respond(w, r, schema.DeleteResponse{
 		Message: fmt.Sprintf("stopped job %s", jobID),
 	})
 }

--- a/pkg/operator/endpoints/stop_task_job.go
+++ b/pkg/operator/endpoints/stop_task_job.go
@@ -46,7 +46,7 @@ func StopTaskJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, schema.DeleteResponse{
+	respondJSON(w, r, schema.DeleteResponse{
 		Message: fmt.Sprintf("stopped job %s", jobID),
 	})
 }

--- a/pkg/operator/endpoints/submit_batch.go
+++ b/pkg/operator/endpoints/submit_batch.go
@@ -94,5 +94,5 @@ func SubmitBatchJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, jobSpec)
+	respond(w, r, jobSpec)
 }

--- a/pkg/operator/endpoints/submit_batch.go
+++ b/pkg/operator/endpoints/submit_batch.go
@@ -94,5 +94,5 @@ func SubmitBatchJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, jobSpec)
+	respondJSON(w, r, jobSpec)
 }

--- a/pkg/operator/endpoints/submit_task.go
+++ b/pkg/operator/endpoints/submit_task.go
@@ -74,5 +74,5 @@ func SubmitTaskJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, r, jobSpec)
+	respondJSON(w, r, jobSpec)
 }

--- a/pkg/operator/endpoints/submit_task.go
+++ b/pkg/operator/endpoints/submit_task.go
@@ -74,5 +74,5 @@ func SubmitTaskJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respond(w, jobSpec)
+	respond(w, r, jobSpec)
 }

--- a/pkg/operator/endpoints/verify_cortex.go
+++ b/pkg/operator/endpoints/verify_cortex.go
@@ -23,5 +23,5 @@ import (
 )
 
 func VerifyCortex(w http.ResponseWriter, r *http.Request) {
-	respond(w, r, schema.VerifyCortexResponse{})
+	respondJSON(w, r, schema.VerifyCortexResponse{})
 }

--- a/pkg/operator/endpoints/verify_cortex.go
+++ b/pkg/operator/endpoints/verify_cortex.go
@@ -23,5 +23,5 @@ import (
 )
 
 func VerifyCortex(w http.ResponseWriter, r *http.Request) {
-	respond(w, schema.VerifyCortexResponse{})
+	respond(w, r, schema.VerifyCortexResponse{})
 }

--- a/pkg/operator/resources/realtimeapi/metrics.go
+++ b/pkg/operator/resources/realtimeapi/metrics.go
@@ -19,6 +19,7 @@ package realtimeapi
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cortexlabs/cortex/pkg/config"
@@ -152,6 +153,10 @@ func getAvgLatencyMetric(promAPIv1 promv1.API, apiSpec spec.API) (*float64, erro
 	}
 
 	avgLatency := float64(values[0].Value)
+
+	if math.IsNaN(avgLatency) {
+		return nil, nil
+	}
 	return &avgLatency, nil
 }
 


### PR DESCRIPTION
This PR addresses the following 2 issues:
* Recover from encoding error on the operator
* Prevent setting the latency to a `NaN` value.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)