### PR TITLE
CaaS - restrict number of jobs shown in `cortex get` to 10

### DIFF
--- a/cli/cmd/lib_batch_apis.go
+++ b/cli/cmd/lib_batch_apis.go
@@ -117,7 +117,7 @@ func batchAPITable(batchAPI schema.APIResponse) string {
 
 		t := table.Table{
 			Headers: []table.Header{
-				{Title: "job id (max 10)"},
+				{Title: "job id (10 max)"},
 				{Title: "status"},
 				{Title: "progress"}, // (succeeded/total)
 				{Title: "failed attempts", Hidden: totalFailed == 0},

--- a/cli/cmd/lib_batch_apis.go
+++ b/cli/cmd/lib_batch_apis.go
@@ -117,7 +117,7 @@ func batchAPITable(batchAPI schema.APIResponse) string {
 
 		t := table.Table{
 			Headers: []table.Header{
-				{Title: "job id"},
+				{Title: "job id (max 10)"},
 				{Title: "status"},
 				{Title: "progress"}, // (succeeded/total)
 				{Title: "failed attempts", Hidden: totalFailed == 0},

--- a/cli/cmd/lib_task_apis.go
+++ b/cli/cmd/lib_task_apis.go
@@ -103,7 +103,7 @@ func taskAPITable(taskAPI schema.APIResponse) string {
 
 		t := table.Table{
 			Headers: []table.Header{
-				{Title: "task job id"},
+				{Title: "task job id (10 max)"},
 				{Title: "status"},
 				{Title: "start time"},
 				{Title: "duration"},

--- a/pkg/operator/resources/job/batchapi/api.go
+++ b/pkg/operator/resources/job/batchapi/api.go
@@ -246,6 +246,8 @@ func GetAPIByName(deployedResource *operator.DeployedResource) ([]schema.APIResp
 				}
 			}
 		}
+	} else {
+		jobStatuses = jobStatuses[:10]
 	}
 
 	dashboardURL := pointer.String(getDashboardURL(api.Name))

--- a/pkg/operator/resources/job/taskapi/api.go
+++ b/pkg/operator/resources/job/taskapi/api.go
@@ -275,6 +275,8 @@ func GetAPIByName(deployedResource *operator.DeployedResource) ([]schema.APIResp
 				break
 			}
 		}
+	} else {
+		jobStatuses = jobStatuses[:10]
 	}
 
 	return []schema.APIResponse{


### PR DESCRIPTION
checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually for the task API
