### PR TITLE
Fix statsd metrics

### DIFF
--- a/manager/manifests/prometheus-monitoring.yaml.j2
+++ b/manager/manifests/prometheus-monitoring.yaml.j2
@@ -221,7 +221,7 @@ metadata:
 spec:
   jobLabel: "statsd-exporter"
   podMetricsEndpoints:
-    - port: admin
+    - port: metrics
       scheme: http
       path: /metrics
       interval: 20s

--- a/pkg/dequeuer/batch_handler.go
+++ b/pkg/dequeuer/batch_handler.go
@@ -58,7 +58,7 @@ type BatchMessageHandlerConfig struct {
 func NewBatchMessageHandler(config BatchMessageHandlerConfig, awsClient *awslib.Client, statsdClient statsd.ClientInterface, log *zap.SugaredLogger) *BatchMessageHandler {
 	tags := []string{
 		"api_name:" + config.APIName,
-		"job_id" + config.JobID,
+		"job_id:" + config.JobID,
 	}
 
 	return &BatchMessageHandler{


### PR DESCRIPTION
Fix tags for statsd metrics in dequeuer and set the correct port name for the pod monitor.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
