### PR TITLE
Display cloudwatch url as output for cortex logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -39,7 +39,7 @@ assignees: ''
 
 ### Stack traces
 
-(error output from `cortex logs <api name>`)
+(error output from CloudWatch Insights or from a random pod `cortex logs <api name>`)
 
 ```text
 <paste stack traces here>

--- a/cli/cluster/logs.go
+++ b/cli/cluster/logs.go
@@ -43,7 +43,7 @@ func GetLogs(operatorConfig OperatorConfig, apiName string) (schema.LogResponse,
 
 	var logResponse schema.LogResponse
 	if err = json.Unmarshal(httpRes, &logResponse); err != nil {
-		return schema.LogResponse{}, errors.Wrap(err, "/get/"+apiName, string(httpRes))
+		return schema.LogResponse{}, errors.Wrap(err, "/logs/"+apiName, string(httpRes))
 	}
 
 	return logResponse, nil
@@ -57,7 +57,7 @@ func GetJobLogs(operatorConfig OperatorConfig, apiName string, jobID string) (sc
 
 	var logResponse schema.LogResponse
 	if err = json.Unmarshal(httpRes, &logResponse); err != nil {
-		return schema.LogResponse{}, errors.Wrap(err, "/get/"+apiName, string(httpRes))
+		return schema.LogResponse{}, errors.Wrap(err, "/logs/"+apiName, string(httpRes))
 	}
 
 	return logResponse, nil

--- a/cli/cluster/logs.go
+++ b/cli/cluster/logs.go
@@ -35,12 +35,40 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+func GetLogs(operatorConfig OperatorConfig, apiName string) (schema.LogResponse, error) {
+	httpRes, err := HTTPGet(operatorConfig, "/logs/"+apiName)
+	if err != nil {
+		return schema.LogResponse{}, err
+	}
+
+	var logResponse schema.LogResponse
+	if err = json.Unmarshal(httpRes, &logResponse); err != nil {
+		return schema.LogResponse{}, errors.Wrap(err, "/get/"+apiName, string(httpRes))
+	}
+
+	return logResponse, nil
+}
+
+func GetJobLogs(operatorConfig OperatorConfig, apiName string, jobID string) (schema.LogResponse, error) {
+	httpRes, err := HTTPGet(operatorConfig, "/logs/"+apiName, map[string]string{"jobID": jobID})
+	if err != nil {
+		return schema.LogResponse{}, err
+	}
+
+	var logResponse schema.LogResponse
+	if err = json.Unmarshal(httpRes, &logResponse); err != nil {
+		return schema.LogResponse{}, errors.Wrap(err, "/get/"+apiName, string(httpRes))
+	}
+
+	return logResponse, nil
+}
+
 func StreamLogs(operatorConfig OperatorConfig, apiName string) error {
-	return streamLogs(operatorConfig, "/logs/"+apiName)
+	return streamLogs(operatorConfig, "/streamlogs/"+apiName)
 }
 
 func StreamJobLogs(operatorConfig OperatorConfig, apiName string, jobID string) error {
-	return streamLogs(operatorConfig, "/logs/"+apiName, map[string]string{"jobID": jobID})
+	return streamLogs(operatorConfig, "/streamlogs/"+apiName, map[string]string{"jobID": jobID})
 }
 
 func streamLogs(operatorConfig OperatorConfig, path string, qParams ...map[string]string) error {

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -240,7 +240,7 @@ func getAPICommandsMessage(results []schema.DeployResult, envName string) (strin
 			continue
 		}
 		if result.API != nil && result.API.Spec.Kind == userconfig.RealtimeAPIKind {
-			items.Add(fmt.Sprintf("cortex logs %s%s", apiName, envArg), "(stream api logs)")
+			items.Add(fmt.Sprintf("cortex logs %s%s", apiName, envArg), "(access logs)")
 			break
 		}
 	}

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -83,7 +83,7 @@ var _logsCmd = &cobra.Command{
 			if err != nil {
 				exit.Error(err)
 			}
-			fmt.Print(fmt.Sprintf(_logsOutput, logResponse.LogURL))
+			fmt.Printf(_logsOutput, logResponse.LogURL)
 			return
 		}
 
@@ -100,6 +100,6 @@ var _logsCmd = &cobra.Command{
 		if err != nil {
 			exit.Error(err)
 		}
-		fmt.Print(fmt.Sprintf(_logsOutput, logResponse.LogURL))
+		fmt.Printf(_logsOutput, logResponse.LogURL)
 	},
 }

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -33,7 +33,7 @@ var (
 
 %s
 
-NOTE: there may be 1-2 minutes of delay for the logs to show up in the CloudWatch Insight queries
+NOTE: there may be 1-2 minutes of delay for the logs to show up in the results of CloudWatch Insight queries
 `
 )
 
@@ -46,7 +46,7 @@ func logsInit() {
 
 var _logsCmd = &cobra.Command{
 	Use:   "logs API_NAME [JOB_ID]",
-	Short: "display CloudWatch insights URL for an api or a job",
+	Short: "get the logs for an API or a job",
 	Args:  cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		envName, err := getEnvFromFlag(_flagLogsEnv)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -122,7 +122,8 @@ func main() {
 	routerWithAuth.HandleFunc("/get", endpoints.GetAPIs).Methods("GET")
 	routerWithAuth.HandleFunc("/get/{apiName}", endpoints.GetAPI).Methods("GET")
 	routerWithAuth.HandleFunc("/get/{apiName}/{apiID}", endpoints.GetAPIByID).Methods("GET")
-	routerWithAuth.HandleFunc("/logs/{apiName}", endpoints.ReadLogs)
+	routerWithAuth.HandleFunc("/streamlogs/{apiName}", endpoints.ReadLogs)
+	routerWithAuth.HandleFunc("/logs/{apiName}", endpoints.LogURL).Methods("GET")
 
 	operatorLogger.Info("Running on port " + _operatorPortStr)
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -123,7 +123,7 @@ func main() {
 	routerWithAuth.HandleFunc("/get/{apiName}", endpoints.GetAPI).Methods("GET")
 	routerWithAuth.HandleFunc("/get/{apiName}/{apiID}", endpoints.GetAPIByID).Methods("GET")
 	routerWithAuth.HandleFunc("/streamlogs/{apiName}", endpoints.ReadLogs)
-	routerWithAuth.HandleFunc("/logs/{apiName}", endpoints.LogURL).Methods("GET")
+	routerWithAuth.HandleFunc("/logs/{apiName}", endpoints.GetLogURL).Methods("GET")
 
 	operatorLogger.Info("Running on port " + _operatorPortStr)
 

--- a/docs/clients/cli.md
+++ b/docs/clients/cli.md
@@ -35,7 +35,7 @@ Flags:
 ## logs
 
 ```text
-display CloudWatch insights URL for an api or a job
+get the logs for an API or a job
 
 Usage:
   cortex logs API_NAME [JOB_ID] [flags]

--- a/docs/clients/cli.md
+++ b/docs/clients/cli.md
@@ -35,7 +35,7 @@ Flags:
 ## logs
 
 ```text
-stream logs from a single replica of an api or a single worker for a job
+display CloudWatch insights URL for an api or a job
 
 Usage:
   cortex logs API_NAME [JOB_ID] [flags]
@@ -43,6 +43,7 @@ Usage:
 Flags:
   -e, --env string   environment to use
   -y, --yes          skip prompts
+      --random-pod   stream logs from a random pod
   -h, --help         help for logs
 ```
 

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -88,7 +88,7 @@ Deploy or update an API.
 
 - `api_spec` - A dictionary defining a single Cortex API. See https://docs.cortex.dev/v/master/ for schema.
 - `force` - Override any in-progress api updates.
-- `wait` - Block until the APIs are ready.
+- `wait` - Block until the API is ready.
 
 
 **Returns**:
@@ -109,7 +109,7 @@ Deploy or update APIs specified in a configuration file.
 
 - `config_file` - Local path to a yaml file defining Cortex API(s). See https://docs.cortex.dev/v/master/ for schema.
 - `force` - Override any in-progress api updates.
-- `wait` - Block until APIs are ready.
+- `wait` - Block until the API is ready.
 
 
 **Returns**:

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -14,8 +14,6 @@
   * [refresh](#refresh)
   * [delete](#delete)
   * [stop\_job](#stop_job)
-  * [stream\_api\_logs](#stream_api_logs)
-  * [stream\_job\_logs](#stream_job_logs)
 
 # cortex
 
@@ -90,7 +88,7 @@ Deploy or update an API.
 
 - `api_spec` - A dictionary defining a single Cortex API. See https://docs.cortex.dev/v/master/ for schema.
 - `force` - Override any in-progress api updates.
-- `wait` - Streams logs until the API is ready.
+- `wait` - Block until the APIs are ready.
 
 
 **Returns**:
@@ -111,7 +109,7 @@ Deploy or update APIs specified in a configuration file.
 
 - `config_file` - Local path to a yaml file defining Cortex API(s). See https://docs.cortex.dev/v/master/ for schema.
 - `force` - Override any in-progress api updates.
-- `wait` - Streams logs until the APIs are ready.
+- `wait` - Block until APIs are ready.
 
 
 **Returns**:
@@ -203,28 +201,3 @@ Stop a running job.
 
 - `api_name` - Name of the Batch/Task API.
 - `job_id` - ID of the Job to stop.
-
-## stream\_api\_logs
-
-```python
- | stream_api_logs(api_name: str)
-```
-
-Stream the logs of an API.
-
-**Arguments**:
-
-- `api_name` - Name of the API.
-
-## stream\_job\_logs
-
-```python
- | stream_job_logs(api_name: str, job_id: str)
-```
-
-Stream the logs of a Job.
-
-**Arguments**:
-
-- `api_name` - Name of the Batch API.
-- `job_id` - Job ID.

--- a/docs/clusters/management/environments.md
+++ b/docs/clusters/management/environments.md
@@ -11,11 +11,9 @@ cortex cluster up cluster1.yaml --configure-env cluster1  # configures the clust
 cortex cluster up cluster2.yaml --configure-env cluster2  # configures the cluster2 env
 
 cortex deploy --env cluster1
-cortex logs my-api --env cluster1
 cortex delete my-api --env cluster1
 
 cortex deploy --env cluster2
-cortex logs my-api --env cluster2
 cortex delete my-api --env cluster2
 ```
 

--- a/docs/clusters/management/environments.md
+++ b/docs/clusters/management/environments.md
@@ -26,11 +26,9 @@ cortex cluster info cluster1.yaml --configure-env cluster1  # configures the clu
 cortex cluster info cluster2.yaml --configure-env cluster2  # configures the cluster2 env
 
 cortex deploy --env cluster1
-cortex logs my-api --env cluster1
 cortex delete my-api --env cluster1
 
 cortex deploy --env cluster2
-cortex logs my-api --env cluster2
 cortex delete my-api --env cluster2
 ```
 

--- a/docs/clusters/observability/logging.md
+++ b/docs/clusters/observability/logging.md
@@ -1,27 +1,14 @@
 # Logging
 
-By default, logs are collected with Fluent Bit and are exported to CloudWatch. It is also possible to view the logs of a single replica using the `cortex logs` command.
-
-## `cortex logs`
-
-The CLI includes a command to get the logs for a single API replica for debugging purposes:
-
-```bash
-# RealtimeAPI
-cortex logs <api_name>
-
-# BatchAPI or TaskAPI
-cortex logs <api_name> <job_id>  # the job needs to be in a running state
-```
-
-**Important:** this method won't show the logs for all the API replicas and therefore is not a complete logging
-solution.
+Logs are collected with Fluent Bit and are exported to CloudWatch.
 
 ## Logs on AWS
 
 Logs will automatically be pushed to CloudWatch and a log group with the same name as your cluster will be created to store your logs. API logs are tagged with labels to help with log aggregation and filtering.
 
-Below are some sample CloudWatch Log Insight queries:
+You can use the `cortex logs` command to get a CloudWatch Insights URL of query to fetch logs for your API.
+
+Please note that there may be a few minutes of delay from when a message is logged to when it is available in CloudWatch insights.
 
 **RealtimeAPI:**
 
@@ -63,6 +50,16 @@ fields @timestamp, message
 | filter cortex.labels.apiKind="TaskAPI"
 | sort @timestamp asc
 | limit 1000
+## Streaming logs for an API or a running job
+
+You can stream logs directly from a random pod of an API or a running job to iterate and debug quickly. These logs will not be as comprehensive as the logs that are available in CloudWatch.
+
+```bash
+# RealtimeAPI
+cortex logs --random-pod <api_name>
+
+# BatchAPI or TaskAPI
+cortex logs --random-pod <api_name> <job_id>  # the job needs to be in a running state
 ```
 
 ## Structured logging

--- a/docs/clusters/observability/logging.md
+++ b/docs/clusters/observability/logging.md
@@ -6,9 +6,7 @@ Logs are collected with Fluent Bit and are exported to CloudWatch.
 
 Logs will automatically be pushed to CloudWatch and a log group with the same name as your cluster will be created to store your logs. API logs are tagged with labels to help with log aggregation and filtering.
 
-You can use the `cortex logs` command to get a CloudWatch Insights URL of query to fetch logs for your API.
-
-Please note that there may be a few minutes of delay from when a message is logged to when it is available in CloudWatch insights.
+You can use the `cortex logs` command to get a CloudWatch Insights URL of query to fetch logs for your API. Please note that there may be a few minutes of delay from when a message is logged to when it is available in CloudWatch Insights.
 
 **RealtimeAPI:**
 
@@ -50,6 +48,8 @@ fields @timestamp, message
 | filter cortex.labels.apiKind="TaskAPI"
 | sort @timestamp asc
 | limit 1000
+```
+
 ## Streaming logs for an API or a running job
 
 You can stream logs directly from a random pod of an API or a running job to iterate and debug quickly. These logs will not be as comprehensive as the logs that are available in CloudWatch.
@@ -59,7 +59,7 @@ You can stream logs directly from a random pod of an API or a running job to ite
 cortex logs --random-pod <api_name>
 
 # BatchAPI or TaskAPI
-cortex logs --random-pod <api_name> <job_id>  # the job needs to be in a running state
+cortex logs --random-pod <api_name> <job_id>  # the job must be in a running state
 ```
 
 ## Structured logging

--- a/docs/workloads/async/example.md
+++ b/docs/workloads/async/example.md
@@ -150,10 +150,9 @@ is `completed`. The result will remain queryable for 7 days after the request wa
 It is also possible to setup a webhook in your handler to get the response sent to a pre-defined web server once the
 workload completes or fails.
 
-## Stream logs
+## Debugging logs
 
-If necessary, you can stream the logs from a random running pod from your API with the `cortex logs` command. This is
-intended for debugging purposes only. For production logs, you can view the logs in cloudwatch logs.
+If necessary, you can view logs for your API in CloudWatch using the `cortex logs` command.
 
 ```bash
 cortex logs iris-classifier

--- a/docs/workloads/batch/example.md
+++ b/docs/workloads/batch/example.md
@@ -125,7 +125,7 @@ print(response.text)
 cortex get image-classifier 69b183ed6bdf3e9b
 ```
 
-## View logs
+## Debugging logs
 
 ```bash
 cortex logs image-classifier 69b183ed6bdf3e9b

--- a/docs/workloads/batch/example.md
+++ b/docs/workloads/batch/example.md
@@ -125,7 +125,7 @@ print(response.text)
 cortex get image-classifier 69b183ed6bdf3e9b
 ```
 
-## Stream logs
+## View logs
 
 ```bash
 cortex logs image-classifier 69b183ed6bdf3e9b

--- a/docs/workloads/realtime/example.md
+++ b/docs/workloads/realtime/example.md
@@ -55,7 +55,7 @@ cortex deploy text_generator.yaml
 cortex get text-generator --watch
 ```
 
-### View logs
+### Debugging logs
 
 ```bash
 cortex logs text-generator

--- a/docs/workloads/realtime/example.md
+++ b/docs/workloads/realtime/example.md
@@ -55,7 +55,7 @@ cortex deploy text_generator.yaml
 cortex get text-generator --watch
 ```
 
-### Stream logs
+### View logs
 
 ```bash
 cortex logs text-generator

--- a/docs/workloads/realtime/troubleshooting.md
+++ b/docs/workloads/realtime/troubleshooting.md
@@ -13,9 +13,9 @@ If you are using API Gateway in front of your API endpoints, it is also possible
 
 If your API is stuck in the "updating" or "compute unavailable" state (which is displayed when running `cortex get`), there are a few possible causes. Here are some things to check:
 
-### Check `cortex logs API_NAME --random-pod`
+### Inspect API logs in CloudWatch
 
-If no logs appear (e.g. it just says "fetching logs..."), continue down this list.
+Use `cortex logs API_NAME` for a URL to view logs for your API in CloudWatch. In addition to output from your containers, you will find logs from other parts of the Cortex infrastructure that may help your troubleshooting.
 
 ### Check `max_instances` for your cluster
 

--- a/docs/workloads/realtime/troubleshooting.md
+++ b/docs/workloads/realtime/troubleshooting.md
@@ -4,8 +4,8 @@
 
 When making requests to your API, it's possible to get a `no healthy upstream` error message (with HTTP status code `503`). This means that there are currently no live replicas running for your API. This could happen for a few reasons:
 
-1. It's possible that your API is simply not ready yet. You can check the status of your API with `cortex get API_NAME`, and stream the logs for a single replica (at random) with `cortex logs API_NAME`.
-1. Your API may have errored during initialization or while responding to a previous request. `cortex get API_NAME` will show the status of your API, and you can view the logs for all replicas via Cloudwatch Logs Insights.
+1. It's possible that your API is simply not ready yet. You can check the status of your API with `cortex get API_NAME`, and inspect the logs in CloudWatch with the help of `cortex logs API_NAME`.
+1. Your API may have errored during initialization or while responding to a previous request. `cortex get API_NAME` will show the status of your API, and you can view the logs for all replicas by visiting the CloudWatch Insights URL from `cortex logs API_NAME`.
 
 If you are using API Gateway in front of your API endpoints, it is also possible to receive a `{"message":"Service Unavailable"}` error message (with HTTP status code `503`) after 29 seconds if your request exceeds API Gateway's 29 second timeout. If this is the case, you can either modify your code to take less time, run on faster hardware (e.g. GPUs), or don't use API Gateway (there is no timeout when using the API's endpoint directly).
 
@@ -13,7 +13,7 @@ If you are using API Gateway in front of your API endpoints, it is also possible
 
 If your API is stuck in the "updating" or "compute unavailable" state (which is displayed when running `cortex get`), there are a few possible causes. Here are some things to check:
 
-### Check `cortex logs API_NAME`
+### Check `cortex logs API_NAME --random-pod`
 
 If no logs appear (e.g. it just says "fetching logs..."), continue down this list.
 

--- a/pkg/operator/endpoints/errors.go
+++ b/pkg/operator/endpoints/errors.go
@@ -120,6 +120,6 @@ func ErrorAnyPathParamRequired(param string, params ...string) error {
 func ErrorLogsJobIDRequired(resource operator.DeployedResource) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrLogsJobIDRequired,
-		Message: fmt.Sprintf("job id is required for %s; you can get a list of latest job ids with `cortex get %s` and use `cortex logs %s JOB_ID`", resource.UserString(), resource.Name, resource.Name),
+		Message: fmt.Sprintf("job id is required for %s ; you can get a list of latest job ids with `cortex get %s` and use `cortex logs %s JOB_ID` to get the logs", resource.UserString(), resource.Name, resource.Name),
 	})
 }

--- a/pkg/operator/endpoints/errors.go
+++ b/pkg/operator/endpoints/errors.go
@@ -120,6 +120,6 @@ func ErrorAnyPathParamRequired(param string, params ...string) error {
 func ErrorLogsJobIDRequired(resource operator.DeployedResource) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrLogsJobIDRequired,
-		Message: fmt.Sprintf("job id is required for %s ; you can get a list of latest job ids with `cortex get %s` and use `cortex logs %s JOB_ID` to get the logs", resource.UserString(), resource.Name, resource.Name),
+		Message: fmt.Sprintf("job id is required for %s; you can get a list of latest job ids with `cortex get %s` and use `cortex logs %s JOB_ID` to get the logs", resource.UserString(), resource.Name, resource.Name),
 	})
 }

--- a/pkg/operator/endpoints/errors.go
+++ b/pkg/operator/endpoints/errors.go
@@ -120,6 +120,6 @@ func ErrorAnyPathParamRequired(param string, params ...string) error {
 func ErrorLogsJobIDRequired(resource operator.DeployedResource) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrLogsJobIDRequired,
-		Message: fmt.Sprintf("job id is required to stream logs for %s; you can get a list of latest job ids with `cortex get %s` and use `cortex logs %s JOB_ID` to stream logs for a job", resource.UserString(), resource.Name, resource.Name),
+		Message: fmt.Sprintf("job id is required for %s; you can get a list of latest job ids with `cortex get %s` and use `cortex logs %s JOB_ID`", resource.UserString(), resource.Name, resource.Name),
 	})
 }

--- a/pkg/operator/endpoints/logs.go
+++ b/pkg/operator/endpoints/logs.go
@@ -71,12 +71,12 @@ func ReadLogs(w http.ResponseWriter, r *http.Request) {
 	operator.StreamLogsFromRandomPod(labels, socket)
 }
 
-func LogURL(w http.ResponseWriter, r *http.Request) {
+func GetLogURL(w http.ResponseWriter, r *http.Request) {
 	apiName := mux.Vars(r)["apiName"]
 	jobID := getOptionalQParam("jobID", r)
 
 	if jobID != "" {
-		JobLogURL(w, r)
+		GetJobLogURL(w, r)
 		return
 	}
 

--- a/pkg/operator/endpoints/logs.go
+++ b/pkg/operator/endpoints/logs.go
@@ -103,7 +103,7 @@ func LogURL(w http.ResponseWriter, r *http.Request) {
 			respondError(w, r, err)
 			return
 		}
-		respond(w, schema.LogResponse{
+		respondJSON(w, r, schema.LogResponse{
 			LogURL: logURL,
 		})
 	case userconfig.RealtimeAPIKind:
@@ -117,7 +117,7 @@ func LogURL(w http.ResponseWriter, r *http.Request) {
 			respondError(w, r, err)
 			return
 		}
-		respond(w, schema.LogResponse{
+		respondJSON(w, r, schema.LogResponse{
 			LogURL: logURL,
 		})
 	default:

--- a/pkg/operator/endpoints/logs.go
+++ b/pkg/operator/endpoints/logs.go
@@ -121,6 +121,6 @@ func LogURL(w http.ResponseWriter, r *http.Request) {
 			LogURL: logURL,
 		})
 	default:
-		respondError(w, r, resources.ErrorOperationIsOnlySupportedForKind(*deployedResource, userconfig.RealtimeAPIKind))
+		respondError(w, r, resources.ErrorOperationIsOnlySupportedForKind(*deployedResource, userconfig.RealtimeAPIKind, userconfig.AsyncAPIKind))
 	}
 }

--- a/pkg/operator/endpoints/logs_job.go
+++ b/pkg/operator/endpoints/logs_job.go
@@ -95,7 +95,7 @@ func JobLogURL(w http.ResponseWriter, r *http.Request) {
 			respondError(w, r, err)
 			return
 		}
-		respond(w, schema.LogResponse{
+		respondJSON(w, r, schema.LogResponse{
 			LogURL: logURL,
 		})
 	case userconfig.TaskAPIKind:
@@ -113,7 +113,7 @@ func JobLogURL(w http.ResponseWriter, r *http.Request) {
 			respondError(w, r, err)
 			return
 		}
-		respond(w, schema.LogResponse{
+		respondJSON(w, r, schema.LogResponse{
 			LogURL: logURL,
 		})
 	default:

--- a/pkg/operator/endpoints/logs_job.go
+++ b/pkg/operator/endpoints/logs_job.go
@@ -65,7 +65,7 @@ func ReadJobLogs(w http.ResponseWriter, r *http.Request) {
 	operator.StreamLogsFromRandomPod(labels, socket)
 }
 
-func JobLogURL(w http.ResponseWriter, r *http.Request) {
+func GetJobLogURL(w http.ResponseWriter, r *http.Request) {
 	apiName := mux.Vars(r)["apiName"]
 	jobID, err := getRequiredQueryParam("jobID", r)
 	if err != nil {

--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cortexlabs/cortex/pkg/config"
 	awslib "github.com/cortexlabs/cortex/pkg/lib/aws"
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
-	"github.com/cortexlabs/cortex/pkg/lib/exit"
 	"github.com/cortexlabs/cortex/pkg/lib/k8s"
 	"github.com/cortexlabs/cortex/pkg/lib/telemetry"
 	"github.com/cortexlabs/cortex/pkg/operator/lib/routines"
@@ -53,35 +52,17 @@ func timeString(t time.Time) string {
 	return fmt.Sprintf("%sT%02d*3a%02d*3a%02d", t.Format("2006-01-02"), t.Hour(), t.Minute(), t.Second())
 }
 
-var _apiLogURLTemplate *template.Template
-
-var _completedJobLogURLTemplate *template.Template
-
-var _inProgressJobLogsURLTemplate *template.Template
-
-func init() {
-	var err error
-	_apiLogURLTemplate, err = template.New("api_log_url_template").Parse(strings.TrimSpace(`
+var _apiLogURLTemplate *template.Template = template.Must(template.New("api_log_url_template").Parse(strings.TrimSpace(`
 	https://console.{{.Partition}}.com/cloudwatch/home?region={{.Region}}#logsV2:logs-insights$3FqueryDetail$3D$257E$2528end$257E0$257Estart$257E-3600$257EtimeType$257E$2527RELATIVE$257Eunit$257E$2527seconds$257EeditorString$257E$2527fields*20*40timestamp*2c*20message*0a*7c*20filter*20cortex.labels.apiName*3d*22{{.APIName}}*22*0a*7c*20sort*20*40timestamp*20asc*0a$257Esource$257E$2528$257E$2527{{.LogGroup}}$2529$2529
-	`))
-	if err != nil {
-		exit.Panic(err)
-	}
+`)))
 
-	_completedJobLogURLTemplate, err = template.New("completed_job_log_url_template").Parse(strings.TrimSpace(`
-	https://console.{{.Partition}}.com/cloudwatch/home?region={{.Region}}#logsV2:logs-insights$3FqueryDetail$3D$257E$2528end$257E$2527{{.EndTime}}$257Estart$257E$2527{{.StartTime}}$257EtimeType$257E$2527ABSOLUTE$257Etz$257E$2527Local$257EeditorString$257E$2527fields*20*40timestamp*2c*20message*0a*7c*20filter*20cortex.labels.apiName*3d*22sum*22*20and*20cortex.labels.jobID*3d*22697ba471c134ea2e*22*0a*7c*20sort*20*40timestamp*20asc*0a$257Esource$257E$2528$257E$2527{{.LogGroup}}$2529$2529
-	`))
-	if err != nil {
-		exit.Panic(err)
-	}
+var _completedJobLogURLTemplate *template.Template = template.Must(template.New("completed_job_log_url_template").Parse(strings.TrimSpace(`
+https://console.{{.Partition}}.com/cloudwatch/home?region={{.Region}}#logsV2:logs-insights$3FqueryDetail$3D$257E$2528end$257E$2527{{.EndTime}}$257Estart$257E$2527{{.StartTime}}$257EtimeType$257E$2527ABSOLUTE$257Etz$257E$2527Local$257EeditorString$257E$2527fields*20*40timestamp*2c*20message*0a*7c*20filter*20cortex.labels.apiName*3d*22sum*22*20and*20cortex.labels.jobID*3d*22697ba471c134ea2e*22*0a*7c*20sort*20*40timestamp*20asc*0a$257Esource$257E$2528$257E$2527{{.LogGroup}}$2529$2529
+`)))
 
-	_inProgressJobLogsURLTemplate, err = template.New("in_progress_job_log_url_template").Parse(strings.TrimSpace(`
-	https://console.{{.Partition}}.com/cloudwatch/home?region={{.Region}}#logsV2:logs-insights$3FqueryDetail$3D$257E$2528end$257E0$257Estart$257E-3600$257EtimeType$257E$2527RELATIVE$257Eunit$257E$2527seconds$257EeditorString$257E$2527fields*20*40timestamp*2c*20message*0a*7c*20filter*20cortex.labels.apiName*3d*22{{.APIName}}*22*20and*20cortex.labels.jobID*3d*22{{.JobID}}*22*0a*7c*20sort*20*40timestamp*20asc*0a$257Esource$257E$2528$257E$2527{{.LogGroup}}$2529$2529
-	`))
-	if err != nil {
-		exit.Panic(err)
-	}
-}
+var _inProgressJobLogsURLTemplate *template.Template = template.Must(template.New("in_progress_job_log_url_template").Parse(strings.TrimSpace(`
+https://console.{{.Partition}}.com/cloudwatch/home?region={{.Region}}#logsV2:logs-insights$3FqueryDetail$3D$257E$2528end$257E0$257Estart$257E-3600$257EtimeType$257E$2527RELATIVE$257Eunit$257E$2527seconds$257EeditorString$257E$2527fields*20*40timestamp*2c*20message*0a*7c*20filter*20cortex.labels.apiName*3d*22{{.APIName}}*22*20and*20cortex.labels.jobID*3d*22{{.JobID}}*22*0a*7c*20sort*20*40timestamp*20asc*0a$257Esource$257E$2528$257E$2527{{.LogGroup}}$2529$2529
+`)))
 
 type apiLogURLTemplateArgs struct {
 	Partition string

--- a/pkg/operator/operator/workload_logging.go
+++ b/pkg/operator/operator/workload_logging.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/cortexlabs/cortex/pkg/config"
 	awslib "github.com/cortexlabs/cortex/pkg/lib/aws"
-	"github.com/cortexlabs/cortex/pkg/lib/debug"
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
 	"github.com/cortexlabs/cortex/pkg/lib/exit"
 	"github.com/cortexlabs/cortex/pkg/lib/k8s"
@@ -137,11 +136,6 @@ func APILogURL(api spec.API) (string, error) {
 	}
 	logGroup := config.ClusterConfig.ClusterName
 
-	secondsAgo := int(time.Now().Unix() - api.LastUpdated)
-	if secondsAgo > 3600 {
-		secondsAgo = 3600
-	}
-
 	args := apiLogURLTemplateArgs{
 		Partition: partition,
 		Region:    region,
@@ -165,7 +159,7 @@ func BatchJobLogURL(apiName string, jobStatus status.BatchJobStatus) (string, er
 		partition = "amazonaws-us-gov"
 	}
 	logGroup := config.ClusterConfig.ClusterName
-	debug.Ppg(jobStatus)
+
 	if jobStatus.EndTime != nil {
 		endTime := *jobStatus.EndTime
 		endTime = endTime.Add(60 * time.Second)

--- a/pkg/operator/schema/schema.go
+++ b/pkg/operator/schema/schema.go
@@ -60,6 +60,10 @@ type APIResponse struct {
 	APIVersions      []APIVersion            `json:"api_versions,omitempty"`
 }
 
+type LogResponse struct {
+	LogURL string `json:"log_url"`
+}
+
 type BatchJobResponse struct {
 	APISpec   spec.API              `json:"api_spec"`
 	JobStatus status.BatchJobStatus `json:"job_status"`

--- a/python/client/cortex/binary/__init__.py
+++ b/python/client/cortex/binary/__init__.py
@@ -61,8 +61,6 @@ def run_cli(
 
     output = ""
     result = ""
-    processing_result = False
-    processed_result = False
 
     for c in iter(lambda: process.stdout.read(1), ""):
         output += c
@@ -70,9 +68,6 @@ def run_cli(
         if not hide_output:
             sys.stdout.write(c)
             sys.stdout.flush()
-
-        if processed_result == True:
-            processing_result = False
 
     process.wait()
 

--- a/python/client/cortex/client.py
+++ b/python/client/cortex/client.py
@@ -114,21 +114,18 @@ class Client:
         if not wait:
             return deploy_result
 
-        # wait a few seconds for the new replicas to start initializing
-        time.sleep(5)
-
         api_name = deploy_result["api"]["spec"]["name"]
-        if deploy_result["api"]["spec"]["kind"] != "RealtimeAPI":
+        if (
+            deploy_result["api"]["spec"]["kind"] != "RealtimeAPI"
+            and deploy_result["api"]["spec"]["kind"] != "AsyncAPI"
+        ):
             return deploy_result
 
-        env = os.environ.copy()
-        env["CORTEX_CLI_INVOKER"] = "python"
-
         while True:
+            time.sleep(5)
             api = self.get_api(api_name)
             if api["status"]["status_code"] != "status_updating":
                 break
-            time.sleep(5)
 
         return api
 

--- a/python/client/cortex/client.py
+++ b/python/client/cortex/client.py
@@ -55,7 +55,7 @@ class Client:
         Args:
             api_spec: A dictionary defining a single Cortex API. See https://docs.cortex.dev/v/master/ for schema.
             force: Override any in-progress api updates.
-            wait: Block until the APIs are ready.
+            wait: Block until the API is ready.
 
         Returns:
             Deployment status, API specification, and endpoint for each API.
@@ -86,7 +86,7 @@ class Client:
         Args:
             config_file: Local path to a yaml file defining Cortex API(s). See https://docs.cortex.dev/v/master/ for schema.
             force: Override any in-progress api updates.
-            wait: Block until the APIs are ready.
+            wait: Block until the API is ready.
 
         Returns:
             Deployment status, API specification, and endpoint for each API.

--- a/python/client/cortex/client.py
+++ b/python/client/cortex/client.py
@@ -55,7 +55,7 @@ class Client:
         Args:
             api_spec: A dictionary defining a single Cortex API. See https://docs.cortex.dev/v/master/ for schema.
             force: Override any in-progress api updates.
-            wait: Streams logs until the API is ready.
+            wait: Block until the APIs are ready.
 
         Returns:
             Deployment status, API specification, and endpoint for each API.
@@ -86,7 +86,7 @@ class Client:
         Args:
             config_file: Local path to a yaml file defining Cortex API(s). See https://docs.cortex.dev/v/master/ for schema.
             force: Override any in-progress api updates.
-            wait: Streams logs until the APIs are ready.
+            wait: Block until the APIs are ready.
 
         Returns:
             Deployment status, API specification, and endpoint for each API.
@@ -114,14 +114,8 @@ class Client:
         if not wait:
             return deploy_result
 
-        # logging immediately will show previous versions of the replica terminating;
         # wait a few seconds for the new replicas to start initializing
         time.sleep(5)
-
-        def stream_to_stdout(process):
-            for c in iter(lambda: process.stdout.read(1), ""):
-                sys.stdout.write(c)
-                sys.stdout.flush()
 
         api_name = deploy_result["api"]["spec"]["name"]
         if deploy_result["api"]["spec"]["kind"] != "RealtimeAPI":
@@ -129,26 +123,12 @@ class Client:
 
         env = os.environ.copy()
         env["CORTEX_CLI_INVOKER"] = "python"
-        process = subprocess.Popen(
-            [get_cli_path(), "logs", "--env", self.env_name, api_name, "-y"],
-            stderr=subprocess.STDOUT,
-            stdout=subprocess.PIPE,
-            encoding="utf8",
-            errors="replace",  # replace non-utf8 characters with `?` instead of failing
-            env=env,
-        )
 
-        streamer = threading.Thread(target=stream_to_stdout, args=[process])
-        streamer.start()
-
-        while process.poll() is None:
+        while True:
             api = self.get_api(api_name)
             if api["status"]["status_code"] != "status_updating":
-                time.sleep(5)  # accommodate latency in log streaming from the cluster
-                process.terminate()
                 break
             time.sleep(5)
-        streamer.join(timeout=10)
 
         return api
 
@@ -259,34 +239,4 @@ class Client:
             "json",
         ]
 
-        run_cli(args)
-
-    @sentry_wrapper
-    def stream_api_logs(
-        self,
-        api_name: str,
-    ):
-        """
-        Stream the logs of an API.
-
-        Args:
-            api_name: Name of the API.
-        """
-        args = ["logs", api_name, "--env", self.env_name, "-y"]
-        run_cli(args)
-
-    @sentry_wrapper
-    def stream_job_logs(
-        self,
-        api_name: str,
-        job_id: str,
-    ):
-        """
-        Stream the logs of a Job.
-
-        Args:
-            api_name: Name of the Batch API.
-            job_id: Job ID.
-        """
-        args = ["logs", api_name, job_id, "--env", self.env_name, "-y"]
         run_cli(args)

--- a/test/e2e/e2e/tests.py
+++ b/test/e2e/e2e/tests.py
@@ -51,6 +51,8 @@ from e2e.utils import (
     make_requests_concurrently,
     check_futures_healthy,
     retrieve_results_concurrently,
+    stream_api_logs,
+    stream_job_logs,
 )
 
 TEST_APIS_DIR = Path(__file__).parent.parent.parent / "apis"
@@ -122,7 +124,7 @@ def test_realtime_api(
         try:
             api_info = client.get_api(api_name)
             printer(json.dumps(api_info, indent=2))
-            td.Thread(target=lambda: client.stream_api_logs(api_name), daemon=True).start()
+            td.Thread(target=lambda: stream_api_logs(client, api_name), daemon=True).start()
             time.sleep(5)
         finally:
             raise
@@ -204,8 +206,10 @@ def test_batch_api(
 
             job_status = client.get_job(api_name, job_spec["job_id"])
             printer(json.dumps(job_status, indent=2))
+
             td.Thread(
-                target=lambda: client.stream_job_logs(api_name, job_spec["job_id"]), daemon=True
+                target=lambda: stream_job_logs(client, api_name, job_spec["job_id"]),
+                daemon=True,
             ).start()
             time.sleep(5)
         finally:
@@ -311,11 +315,9 @@ def test_async_api(
         try:
             api_info = client.get_api(api_name)
             printer(json.dumps(api_info, indent=2))
-
-            job_status = client.get_job(api_name, result_response_json["id"])
-            printer(json.dumps(job_status, indent=2))
+            printer(json.dumps(result_response_json, indent=2))
             td.Thread(
-                target=lambda: client.stream_job_logs(api_name, result_response_json["id"]),
+                target=lambda: stream_api_logs(client, api_name),
                 daemon=True,
             ).start()
             time.sleep(5)
@@ -386,7 +388,7 @@ def test_task_api(
             job_status = client.get_job(api_name, job_spec["job_id"])
             printer(json.dumps(job_status, indent=2))
             td.Thread(
-                target=lambda: client.stream_job_logs(api_name, job_spec["job_id"]), daemon=True
+                target=lambda: stream_job_logs(client, api_name, job_spec["job_id"]), daemon=True
             ).start()
             time.sleep(5)
         except:
@@ -986,7 +988,7 @@ def test_long_running_realtime(
         try:
             api_info = client.get_api(api_name)
             printer(json.dumps(api_info, indent=2))
-            td.Thread(target=lambda: client.stream_api_logs(api_name), daemon=True).start()
+            td.Thread(target=lambda: stream_api_logs(client, api_name), daemon=True).start()
             time.sleep(5)
         finally:
             raise

--- a/test/e2e/e2e/utils.py
+++ b/test/e2e/e2e/utils.py
@@ -416,3 +416,10 @@ def client_from_config(config_path: str) -> cx.Client:
     cluster_name = config["cluster_name"]
 
     return cx.client(f"{cluster_name}")
+
+
+def stream_api_logs(client: cx.Client, api_name: str):
+    cx.run_cli(["logs", api_name, "--random-pod", "-e", client.env_name])
+
+def stream_job_logs(client: cx.Client, api_name: str, job_id: str):
+    cx.run_cli(["logs", api_name, job_id, "--random-pod", "-e", client.env_name])

--- a/test/e2e/e2e/utils.py
+++ b/test/e2e/e2e/utils.py
@@ -421,5 +421,6 @@ def client_from_config(config_path: str) -> cx.Client:
 def stream_api_logs(client: cx.Client, api_name: str):
     cx.run_cli(["logs", api_name, "--random-pod", "-e", client.env_name])
 
+
 def stream_job_logs(client: cx.Client, api_name: str, job_id: str):
     cx.run_cli(["logs", api_name, job_id, "--random-pod", "-e", client.env_name])


### PR DESCRIPTION
Display cloudwatch url as the output for cortex logs. Add a flag: `--random-pod` to stream logs from a random pod.