### PR TITLE
CaaS - fix respond function

### DIFF
--- a/pkg/lib/json/json.go
+++ b/pkg/lib/json/json.go
@@ -89,3 +89,10 @@ func Pretty(obj interface{}) (string, error) {
 
 	return string(b), nil
 }
+
+func IsJSONParseable(obj interface{}) bool {
+	if _, err := MarshalJSONStr(obj); err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/lib/json/json.go
+++ b/pkg/lib/json/json.go
@@ -89,10 +89,3 @@ func Pretty(obj interface{}) (string, error) {
 
 	return string(b), nil
 }
-
-func IsJSONParseable(obj interface{}) bool {
-	if _, err := MarshalJSONStr(obj); err != nil {
-		return false
-	}
-	return true
-}

--- a/pkg/operator/endpoints/respond.go
+++ b/pkg/operator/endpoints/respond.go
@@ -31,6 +31,7 @@ var operatorLogger = logging.GetLogger()
 func respondJSON(w http.ResponseWriter, r *http.Request, response interface{}) {
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		respondError(w, r, errors.Wrap(err, "failed to encode response"))
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/pkg/operator/endpoints/respond.go
+++ b/pkg/operator/endpoints/respond.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/cortexlabs/cortex/pkg/lib/errors"
+	libjson "github.com/cortexlabs/cortex/pkg/lib/json"
 	"github.com/cortexlabs/cortex/pkg/lib/logging"
 	"github.com/cortexlabs/cortex/pkg/lib/telemetry"
 	"github.com/cortexlabs/cortex/pkg/operator/schema"
@@ -29,12 +30,15 @@ import (
 var operatorLogger = logging.GetLogger()
 
 func respondJSON(w http.ResponseWriter, r *http.Request, response interface{}) {
-	if err := json.NewEncoder(w).Encode(response); err != nil {
+	jsonBytes, err := libjson.Marshal(response)
+	if err != nil {
 		respondError(w, r, errors.Wrap(err, "failed to encode response"))
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	w.Write(jsonBytes)
 }
 
 func respondError(w http.ResponseWriter, r *http.Request, err error, strs ...string) {


### PR DESCRIPTION
Fixes `http: superfluous response.WriteHeader call from github.com/cortexlabs/cortex/pkg/operator/endpoints.respondJSON (respond.go:36)` error.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)