### PR TITLE
Fix exception when creating Python client without default env set

### DIFF
--- a/cli/cmd/env.go
+++ b/cli/cmd/env.go
@@ -97,10 +97,6 @@ var _envListCmd = &cobra.Command{
 		}
 
 		if _flagOutput == flags.JSONOutputType {
-			if len(cliConfig.Environments) == 0 {
-				fmt.Print("[]")
-				return
-			}
 			bytes, err := libjson.Marshal(cliConfig.ConvertToUserFacingCLIConfig())
 			if err != nil {
 				exit.Error(err)

--- a/cli/types/cliconfig/cli_config.go
+++ b/cli/types/cliconfig/cli_config.go
@@ -57,8 +57,12 @@ func (cliConfig *CLIConfig) Validate() error {
 }
 
 func (cliConfig *CLIConfig) ConvertToUserFacingCLIConfig() UserFacingCLIConfig {
+	envs := cliConfig.Environments
+	if envs == nil {
+		envs = []*Environment{}
+	}
 	return UserFacingCLIConfig{
 		DefaultEnvironment: cliConfig.DefaultEnvironment,
-		Environments:       cliConfig.Environments,
+		Environments:       envs,
 	}
 }


### PR DESCRIPTION
closes #2223