### PR TITLE
Remove latency checks for realtime load test & increase workload timeouts

### DIFF
--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -84,11 +84,11 @@ def pytest_configure(config):
         "global": {
             "local_operator": config.getoption("--local-operator"),
             "realtime_deploy_timeout": int(
-                os.environ.get("CORTEX_TEST_REALTIME_DEPLOY_TIMEOUT", 200)
+                os.environ.get("CORTEX_TEST_REALTIME_DEPLOY_TIMEOUT", 320)
             ),
             "batch_deploy_timeout": int(os.environ.get("CORTEX_TEST_BATCH_DEPLOY_TIMEOUT", 150)),
             "batch_job_timeout": int(os.environ.get("CORTEX_TEST_BATCH_JOB_TIMEOUT", 200)),
-            "async_deploy_timeout": int(os.environ.get("CORTEX_TEST_ASYNC_DEPLOY_TIMEOUT", 150)),
+            "async_deploy_timeout": int(os.environ.get("CORTEX_TEST_ASYNC_DEPLOY_TIMEOUT", 320)),
             "async_workload_timeout": int(
                 os.environ.get("CORTEX_TEST_ASYNC_WORKLOAD_TIMEOUT", 200)
             ),

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -107,10 +107,6 @@ def pytest_configure(config):
                     "total_requests": 10 ** 5,
                     "desired_replicas": 50,
                     "concurrency": 50,
-                    "min_rtt": 0.004,  # measured in seconds
-                    "max_rtt": 1.200,  # measured in seconds
-                    "avg_rtt": 0.07,  # measured in seconds
-                    "avg_rtt_tolerance": 0.06,  # measured in seconds
                     "status_code_timeout": 60,  # measured in seconds
                 },
                 "async": {

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -121,7 +121,7 @@ def pytest_configure(config):
                     "workers_per_job": 10,
                     "items_per_job": 10 ** 5,
                     "batch_size": 10 * 2,
-                    "workload_timeout": 200,  # measured in seconds
+                    "workload_timeout": 300,  # measured in seconds
                 },
                 "task": {
                     "jobs": 10 ** 2,


### PR DESCRIPTION
Since the latency checks don't appear to be 100% reliable during the nightly test due to external factors (the CI box living close or far away from the cluster on different occasions), it's better if we remove them temporarily until a better solution is designed.

We could have loosened the restrictions on what an acceptable latency is, but at the end of the day:
1. It's probably better if we have a different test (separate from the load test) that's specifically meant for evaluating the quantile values of the latencies in a well-defined manner (needs design).
2. Same as 1, but embedded in the current load test.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
