### PR TITLE
Persist BatchJob metrics regardless of status

### DIFF
--- a/pkg/crds/controllers/batch/batchjob_controller_helpers.go
+++ b/pkg/crds/controllers/batch/batchjob_controller_helpers.go
@@ -636,9 +636,6 @@ func (r *BatchJobReconciler) updateCompletedTimestamp(ctx context.Context, batch
 func (r *BatchJobReconciler) persistJobToS3(batchJob batch.BatchJob) error {
 	return parallel.RunFirstErr(
 		func() error {
-			if batchJob.Status.Status != status.JobSucceeded && batchJob.Status.Status != status.JobCompletedWithFailures {
-				return nil
-			}
 			return r.Config.SaveJobMetrics(r, batchJob)
 		},
 		func() error {


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

