### PR TITLE
Enable SSE for cluster bucket (bucket-wide instead of per-object)

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -1169,6 +1169,11 @@ func createS3BucketIfNotFound(awsClient *aws.Client, bucket string, tags map[str
 			fmt.Print("\n\n")
 			return err
 		}
+		err = awsClient.EnableBucketEncryption(bucket)
+		if err != nil {
+			fmt.Print("\n\n")
+			return err
+		}
 	} else {
 		fmt.Print("￮ using existing s3 bucket: ", bucket)
 	}

--- a/pkg/lib/aws/s3.go
+++ b/pkg/lib/aws/s3.go
@@ -373,17 +373,31 @@ func (c *Client) CreateBucket(bucket string) error {
 	if err != nil {
 		return errors.Wrap(err, "creating bucket "+bucket)
 	}
+	_, err = c.S3().PutBucketEncryption(&s3.PutBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
+			Rules: []*s3.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
+						SSEAlgorithm: pointer.String("AES256"),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "enabling encryption for bucket "+bucket)
+	}
 	return nil
 }
 
 func (c *Client) UploadReaderToS3(data io.Reader, bucket string, key string) error {
 	_, err := c.S3Uploader().Upload(&s3manager.UploadInput{
-		Bucket:               aws.String(bucket),
-		Key:                  aws.String(key),
-		Body:                 data,
-		ACL:                  aws.String("private"),
-		ContentDisposition:   aws.String("attachment"),
-		ServerSideEncryption: aws.String("AES256"),
+		Bucket:             aws.String(bucket),
+		Key:                aws.String(key),
+		Body:               data,
+		ACL:                aws.String("private"),
+		ContentDisposition: aws.String("attachment"),
 	})
 
 	if err != nil {

--- a/pkg/lib/aws/s3.go
+++ b/pkg/lib/aws/s3.go
@@ -373,7 +373,11 @@ func (c *Client) CreateBucket(bucket string) error {
 	if err != nil {
 		return errors.Wrap(err, "creating bucket "+bucket)
 	}
-	_, err = c.S3().PutBucketEncryption(&s3.PutBucketEncryptionInput{
+	return nil
+}
+
+func (c *Client) EnableBucketEncryption(bucket string) error {
+	_, err := c.S3().PutBucketEncryption(&s3.PutBucketEncryptionInput{
 		Bucket: aws.String(bucket),
 		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
 			Rules: []*s3.ServerSideEncryptionRule{


### PR DESCRIPTION
Closes #2235

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
