### PR TITLE
Prevent `"unexpected_error"` status on the Task API from surfacing

### DIFF
--- a/pkg/operator/resources/job/taskapi/cron.go
+++ b/pkg/operator/resources/job/taskapi/cron.go
@@ -43,7 +43,6 @@ const (
 
 var operatorLogger = logging.GetLogger()
 var _inProgressJobSpecMap = map[string]*spec.TaskJob{}
-var _notFoundK8sJobs = strset.New()
 
 func ManageJobResources() error {
 	inProgressJobKeys, err := job.ListAllInProgressJobKeys(userconfig.TaskAPIKind)
@@ -110,16 +109,6 @@ func ManageJobResources() error {
 			_ = job.DeleteInProgressFile(jobKey)
 			_ = deleteJobRuntimeResources(jobKey)
 			continue
-		}
-
-		// if a k8s job hasn't been found, it could be because the k8s job hasn't been created yet
-		// the explanation is that job states are uploaded first and then are the k8s jobs created
-		if !jobFound && !_notFoundK8sJobs.Has(jobKey.ID) {
-			_notFoundK8sJobs.Add(jobKey.ID)
-			continue
-		}
-		if _notFoundK8sJobs.Has(jobKey.ID) {
-			_notFoundK8sJobs.Remove(jobKey.ID)
 		}
 
 		// reconcile job state and k8s job

--- a/pkg/operator/resources/job/taskapi/cron.go
+++ b/pkg/operator/resources/job/taskapi/cron.go
@@ -43,6 +43,7 @@ const (
 
 var operatorLogger = logging.GetLogger()
 var _inProgressJobSpecMap = map[string]*spec.TaskJob{}
+var _notFoundK8sJobs = strset.New()
 
 func ManageJobResources() error {
 	inProgressJobKeys, err := job.ListAllInProgressJobKeys(userconfig.TaskAPIKind)
@@ -109,6 +110,16 @@ func ManageJobResources() error {
 			_ = job.DeleteInProgressFile(jobKey)
 			_ = deleteJobRuntimeResources(jobKey)
 			continue
+		}
+
+		// if a k8s job hasn't been found, it could be because the k8s job hasn't been created yet
+		// the explanation is that job states are uploaded first and then are the k8s jobs created
+		if !jobFound && !_notFoundK8sJobs.Has(jobKey.ID) {
+			_notFoundK8sJobs.Add(jobKey.ID)
+			continue
+		}
+		if _notFoundK8sJobs.Has(jobKey.ID) {
+			_notFoundK8sJobs.Remove(jobKey.ID)
 		}
 
 		// reconcile job state and k8s job

--- a/test/e2e/e2e/tests.py
+++ b/test/e2e/e2e/tests.py
@@ -880,7 +880,7 @@ def test_load_task(
         printer(f"submitting {jobs} jobs concurrently")
         job_specs = []
         threads_futures = request_tasks_concurrently(
-            client, api_name, request_stopper, concurrency, jobs, job_specs
+            client, api_name, request_stopper, 1, jobs, job_specs
         )
 
         assert wait_on_event(

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -125,8 +125,8 @@ def pytest_configure(config):
                 },
                 "task": {
                     "jobs": 10 ** 2,
-                    "concurrency": 4,
-                    "submit_timeout": 200,  # measured in seconds
+                    "concurrency": 1,
+                    "submit_timeout": 400,  # measured in seconds
                     "workload_timeout": 400,  # measured in seconds
                 },
             },

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -126,7 +126,7 @@ def pytest_configure(config):
                 "task": {
                     "jobs": 10 ** 2,
                     "concurrency": 1,
-                    "submit_timeout": 400,  # measured in seconds
+                    "submit_timeout": 150,  # measured in seconds
                     "workload_timeout": 400,  # measured in seconds
                 },
             },

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -125,7 +125,7 @@ def pytest_configure(config):
                 },
                 "task": {
                     "jobs": 10 ** 2,
-                    "concurrency": 1,
+                    "concurrency": 4,  # task-retrieving concurrency
                     "submit_timeout": 150,  # measured in seconds
                     "workload_timeout": 400,  # measured in seconds
                 },


### PR DESCRIPTION
Closes #2215.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)