### PR TITLE
Fix EndTime nil pointer when persisting metrics

### DIFF
--- a/pkg/crds/controllers/batch/batchjob_controller_helpers.go
+++ b/pkg/crds/controllers/batch/batchjob_controller_helpers.go
@@ -672,10 +672,11 @@ func getMetrics(r *BatchJobReconciler, batchJob batch.BatchJob) (metrics.BatchMe
 		ID:      batchJob.Name,
 		APIName: batchJob.Spec.APIName,
 		Kind:    userconfig.BatchAPIKind,
-	}, batchJob.Status.EndTime.Time)
+	}, time.Now())
 	if err != nil {
 		return metrics.BatchMetrics{}, err
 	}
+
 	return jobMetrics, nil
 }
 

--- a/pkg/crds/controllers/batch/batchjob_controller_helpers.go
+++ b/pkg/crds/controllers/batch/batchjob_controller_helpers.go
@@ -681,11 +681,16 @@ func getTotalBatchCount(r *BatchJobReconciler, batchJob batch.BatchJob) (int, er
 }
 
 func getMetrics(r *BatchJobReconciler, batchJob batch.BatchJob) (metrics.BatchMetrics, error) {
+	endTime := time.Now()
+	if batchJob.Status.EndTime != nil {
+		endTime = batchJob.Status.EndTime.Time
+	}
+
 	jobMetrics, err := batch.GetMetrics(r.Prometheus, spec.JobKey{
 		ID:      batchJob.Name,
 		APIName: batchJob.Spec.APIName,
 		Kind:    userconfig.BatchAPIKind,
-	}, time.Now())
+	}, endTime)
 	if err != nil {
 		return metrics.BatchMetrics{}, err
 	}


### PR DESCRIPTION
Previously we used to get a snapshot of the batch metrics based on the job EndTime. The EndTime field would be nil if the job didn't complete due to an unhandled worker error. In such cases, controller would encounter a nil pointer error.

The controller has been updated to get a snapshot of the metrics in prometheus based on the current time rather than the EndTime so that even in situations where EndTime is nil, it tries to get the most accurate metrics.

---

checklist:

- [ ] run `make test` and `make lint`
- [X] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

