### PR TITLE
Add call to logger.Sync() on the test loggers and fix dequeuer test

### DIFF
--- a/pkg/dequeuer/async_handler_test.go
+++ b/pkg/dequeuer/async_handler_test.go
@@ -39,6 +39,8 @@ func TestAsyncMessageHandler_Handle(t *testing.T) {
 	t.Parallel()
 
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
+
 	awsClient := testAWSClient(t)
 
 	requestID := random.String(8)
@@ -109,6 +111,8 @@ func TestAsyncMessageHandler_Handle_Errors(t *testing.T) {
 	}
 
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
+
 	awsClient := testAWSClient(t)
 
 	eventHandler := NewRequestEventHandlerFunc(func(event RequestEvent) {})

--- a/pkg/dequeuer/batch_handler_test.go
+++ b/pkg/dequeuer/batch_handler_test.go
@@ -39,12 +39,15 @@ func TestBatchMessageHandler_Handle(t *testing.T) {
 		}),
 	)
 
+	logger := newLogger(t)
+	defer func() { _ = logger.Sync() }()
+
 	batchHandler := NewBatchMessageHandler(BatchMessageHandlerConfig{
 		APIName:   "test",
 		JobID:     "12345",
 		Region:    _localStackDefaultRegion,
 		TargetURL: server.URL,
-	}, awsClient, &statsd.NoOpClient{}, newLogger(t))
+	}, awsClient, &statsd.NoOpClient{}, logger)
 
 	err := batchHandler.Handle(&sqs.Message{
 		Body:      aws.String(""),
@@ -72,13 +75,16 @@ func TestBatchMessageHandler_Handle_OnJobComplete(t *testing.T) {
 	})
 	server := httptest.NewServer(mux)
 
+	logger := newLogger(t)
+	defer func() { _ = logger.Sync() }()
+
 	batchHandler := NewBatchMessageHandler(BatchMessageHandlerConfig{
 		APIName:   "test",
 		JobID:     "12345",
 		Region:    _localStackDefaultRegion,
 		TargetURL: server.URL,
 		QueueURL:  queueURL,
-	}, awsClient, &statsd.NoOpClient{}, newLogger(t))
+	}, awsClient, &statsd.NoOpClient{}, logger)
 
 	batchHandler.jobCompleteMessageDelay = 0
 

--- a/pkg/dequeuer/dequeuer_test.go
+++ b/pkg/dequeuer/dequeuer_test.go
@@ -171,12 +171,15 @@ func TestSQSDequeuer_ReceiveMessage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	logger := newLogger(t)
+	defer func() { _ = logger.Sync() }()
+
 	dq, err := NewSQSDequeuer(
 		SQSDequeuerConfig{
 			Region:           _localStackDefaultRegion,
 			QueueURL:         queueURL,
 			StopIfNoMessages: true,
-		}, awsClient, newLogger(t),
+		}, awsClient, logger,
 	)
 	require.NoError(t, err)
 
@@ -194,12 +197,15 @@ func TestSQSDequeuer_StartMessageRenewer(t *testing.T) {
 	awsClient := testAWSClient(t)
 	queueURL := createQueue(t, awsClient)
 
+	logger := newLogger(t)
+	defer func() { _ = logger.Sync() }()
+
 	dq, err := NewSQSDequeuer(
 		SQSDequeuerConfig{
 			Region:           _localStackDefaultRegion,
 			QueueURL:         queueURL,
 			StopIfNoMessages: true,
-		}, awsClient, newLogger(t),
+		}, awsClient, logger,
 	)
 	require.NoError(t, err)
 
@@ -239,12 +245,15 @@ func TestSQSDequeuerTerminationOnEmptyQueue(t *testing.T) {
 	awsClient := testAWSClient(t)
 	queueURL := createQueue(t, awsClient)
 
+	logger := newLogger(t)
+	defer func() { _ = logger.Sync() }()
+
 	dq, err := NewSQSDequeuer(
 		SQSDequeuerConfig{
 			Region:           _localStackDefaultRegion,
 			QueueURL:         queueURL,
 			StopIfNoMessages: true,
-		}, awsClient, newLogger(t),
+		}, awsClient, logger,
 	)
 	require.NoError(t, err)
 
@@ -286,12 +295,15 @@ func TestSQSDequeuer_Shutdown(t *testing.T) {
 	awsClient := testAWSClient(t)
 	queueURL := createQueue(t, awsClient)
 
+	logger := newLogger(t)
+	defer func() { _ = logger.Sync() }()
+
 	dq, err := NewSQSDequeuer(
 		SQSDequeuerConfig{
 			Region:           _localStackDefaultRegion,
 			QueueURL:         queueURL,
 			StopIfNoMessages: true,
-		}, awsClient, newLogger(t),
+		}, awsClient, logger,
 	)
 	require.NoError(t, err)
 
@@ -325,12 +337,15 @@ func TestSQSDequeuer_Start_HandlerError(t *testing.T) {
 	awsClient := testAWSClient(t)
 	queueURL := createQueue(t, awsClient)
 
+	logger := newLogger(t)
+	defer func() { _ = logger.Sync() }()
+
 	dq, err := NewSQSDequeuer(
 		SQSDequeuerConfig{
 			Region:           _localStackDefaultRegion,
 			QueueURL:         queueURL,
 			StopIfNoMessages: true,
-		}, awsClient, newLogger(t),
+		}, awsClient, logger,
 	)
 	require.NoError(t, err)
 

--- a/pkg/dequeuer/dequeuer_test.go
+++ b/pkg/dequeuer/dequeuer_test.go
@@ -351,7 +351,7 @@ func TestSQSDequeuer_Start_HandlerError(t *testing.T) {
 
 	dq.waitTimeSeconds = aws.Int64(0)
 	dq.notFoundSleepTime = 0
-	dq.renewalPeriod = time.Second
+	dq.renewalPeriod = 500 * time.Millisecond
 	dq.visibilityTimeout = aws.Int64(1)
 
 	msgHandler := NewMessageHandlerFunc(
@@ -370,10 +370,12 @@ func TestSQSDequeuer_Start_HandlerError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = dq.Start(msgHandler, func() bool {
-		return true
-	})
-	require.NoError(t, err)
+	go func() {
+		err := dq.Start(msgHandler, func() bool {
+			return true
+		})
+		require.NoError(t, err)
+	}()
 
 	require.Never(t, func() bool {
 		msg, err := dq.ReceiveMessage()

--- a/pkg/dequeuer/probes_test.go
+++ b/pkg/dequeuer/probes_test.go
@@ -27,7 +27,9 @@ import (
 
 func TestDefaultTCPProbeNotPresent(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	userPodPort := 8080
 
@@ -63,7 +65,9 @@ func TestDefaultTCPProbeNotPresent(t *testing.T) {
 
 func TestDefaultTCPProbePresent(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	userPodPort := intstr.FromInt(8080)
 

--- a/pkg/probe/handler_test.go
+++ b/pkg/probe/handler_test.go
@@ -44,7 +44,9 @@ func generateHandler(pb *probe.Probe) http.HandlerFunc {
 
 func TestHandlerSuccessTCP(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	var userHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -77,7 +79,9 @@ func TestHandlerSuccessTCP(t *testing.T) {
 
 func TestHandlerSuccessHTTP(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	headers := []kcore.HTTPHeader{
 		{

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -45,7 +45,9 @@ func newLogger(t *testing.T) *zap.SugaredLogger {
 
 func TestDefaultProbeSuccess(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -70,7 +72,9 @@ func TestDefaultProbeSuccess(t *testing.T) {
 
 func TestDefaultProbeFailure(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	target := "http://127.0.0.1:12345"
 	pb := probe.NewDefaultProbe(target, log)
@@ -92,7 +96,9 @@ func TestDefaultProbeFailure(t *testing.T) {
 
 func TestProbeHTTPFailure(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	pb := probe.NewProbe(
 		&kcore.Probe{
@@ -128,7 +134,9 @@ func TestProbeHTTPFailure(t *testing.T) {
 
 func TestProbeHTTPSuccess(t *testing.T) {
 	t.Parallel()
+
 	log := newLogger(t)
+	defer func() { _ = log.Sync() }()
 
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
