### PR TITLE
Fix async metrics request count

### DIFF
--- a/pkg/dequeuer/async_handler.go
+++ b/pkg/dequeuer/async_handler.go
@@ -189,10 +189,12 @@ func (h *AsyncMessageHandler) submitRequest(payload *userPayload, requestID stri
 		_ = response.Body.Close()
 	}()
 
-	requestEvent := RequestEvent{
-		StatusCode: response.StatusCode,
-		Duration:   time.Since(startTime),
-	}
+	h.eventHandler.HandleEvent(
+		RequestEvent{
+			StatusCode: response.StatusCode,
+			Duration:   time.Since(startTime),
+		},
+	)
 
 	if response.StatusCode != http.StatusOK {
 		return nil, ErrorUserContainerResponseStatusCode(response.StatusCode)
@@ -206,8 +208,6 @@ func (h *AsyncMessageHandler) submitRequest(payload *userPayload, requestID stri
 	if err = json.NewDecoder(response.Body).Decode(&result); err != nil {
 		return nil, ErrorUserContainerResponseNotJSONDecodable()
 	}
-
-	h.eventHandler.HandleEvent(requestEvent)
 
 	return result, nil
 }


### PR DESCRIPTION
Fix async metrics request event handling for non-200 status codes

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

