### PR TITLE
Move async queue length metrics to dequeuer

### DIFF
--- a/cmd/dequeuer/main.go
+++ b/cmd/dequeuer/main.go
@@ -180,7 +180,10 @@ func main() {
 			TargetURL:  targetURL,
 		}
 
-		asyncStatsReporter := dequeuer.NewAsyncPrometheusStatsReporter()
+		asyncStatsReporter := dequeuer.NewAsyncPrometheusStatsReporter(awsClient.SQS(), queueURL, log)
+		stopStatsReporter := asyncStatsReporter.Start()
+		defer stopStatsReporter()
+
 		messageHandler = dequeuer.NewAsyncMessageHandler(config, awsClient, asyncStatsReporter, log)
 		dequeuerConfig = dequeuer.SQSDequeuerConfig{
 			Region:           clusterConfig.Region,

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -81,10 +81,6 @@ func main() {
 					operatorLogger.Fatal(errors.Wrap(err, "init"))
 				}
 			case userconfig.AsyncAPIKind:
-				if err := asyncapi.UpdateAPIMetricsCron(&deployment); err != nil {
-					operatorLogger.Fatal(errors.Wrap(err, "init"))
-				}
-
 				if err := asyncapi.UpdateAPIAutoscalerCron(&deployment, *api); err != nil {
 					operatorLogger.Fatal(errors.Wrap(err, "init"))
 				}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cortexlabs/cortex/pkg/types/userconfig"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var operatorLogger = logging.GetLogger()
@@ -105,9 +104,6 @@ func main() {
 	routerWithoutAuth.HandleFunc("/tasks/{apiName}", endpoints.SubmitTaskJob).Methods("POST")
 	routerWithoutAuth.HandleFunc("/tasks/{apiName}", endpoints.GetTaskJob).Methods("GET")
 	routerWithoutAuth.HandleFunc("/tasks/{apiName}", endpoints.StopTaskJob).Methods("DELETE")
-
-	// prometheus metrics
-	routerWithoutAuth.Handle("/metrics", promhttp.Handler()).Methods("GET")
 
 	routerWithAuth := router.NewRoute().Subrouter()
 

--- a/manager/manifests/prometheus-monitoring.yaml.j2
+++ b/manager/manifests/prometheus-monitoring.yaml.j2
@@ -281,25 +281,3 @@ spec:
   selector:
     matchLabels:
       name: prometheus-statsd-exporter
-
----
-
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: operator
-  labels:
-    name: operator
-    monitoring.cortex.dev: "operator"
-spec:
-  jobLabel: "operator"
-  endpoints:
-    - port: http
-      scheme: http
-      path: /metrics
-      interval: 10s
-  namespaceSelector:
-    any: true
-  selector:
-    matchLabels:
-      cortex.dev/name: operator

--- a/pkg/dequeuer/async_stats_test.go
+++ b/pkg/dequeuer/async_stats_test.go
@@ -31,7 +31,7 @@ import (
 func TestNewAsyncPrometheusStatsReporter(t *testing.T) {
 	t.Parallel()
 
-	statsReporter := NewAsyncPrometheusStatsReporter()
+	statsReporter := NewAsyncPrometheusStatsReporter(nil, "", nil)
 
 	statsReporter.HandleEvent(
 		RequestEvent{


### PR DESCRIPTION
closes #2280 

---

checklist:

- [x] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

