### PR TITLE
Fix cluster-autoscaler-priority expander

### DIFF
--- a/manager/manifests/cluster-autoscaler.yaml.j2
+++ b/manager/manifests/cluster-autoscaler.yaml.j2
@@ -137,13 +137,25 @@ metadata:
   namespace: kube-system
 data:
   priorities: |-
-  {% for ng in config['node_groups']|reverse %}
-    {{ (loop.index0+1) * 10 }}:
-    {% if ng['spot'] %}
-      - .*{{ 'cx-ws-' + ng['name'] }}.*
-    {% else %}
-      - .*{{ 'cx-wd-' + ng['name'] }}.*
+  {% for p in range(1, 100) %}
+    {% set found = {'priority': False} %}
+    {% for ng in config['node_groups'] %}
+      {% if ng['priority'] == p %}
+        {%- if found.update({'priority':True}) %} {%- endif %}
+      {% endif %}
+    {% endfor %}
+    {% if found['priority'] %}
+    {{ 101-p }}:
     {% endif %}
+    {% for ng in config['node_groups'] %}
+      {% if ng['priority'] == p %}
+      {% if ng['spot'] %}
+      - .*{{ 'cx-ws-' + ng['name'] }}.*
+      {% else %}
+      - .*{{ 'cx-wd-' + ng['name'] }}.*
+      {% endif %}
+      {% endif %}
+    {% endfor %}
   {% endfor %}
 ---
 apiVersion: apps/v1

--- a/manager/manifests/cluster-autoscaler.yaml.j2
+++ b/manager/manifests/cluster-autoscaler.yaml.j2
@@ -149,11 +149,11 @@ data:
     {% endif %}
     {% for ng in config['node_groups'] %}
       {% if ng['priority'] == p %}
-      {% if ng['spot'] %}
+        {% if ng['spot'] %}
       - .*{{ 'cx-ws-' + ng['name'] }}.*
-      {% else %}
+        {% else %}
       - .*{{ 'cx-wd-' + ng['name'] }}.*
-      {% endif %}
+        {% endif %}
       {% endif %}
     {% endfor %}
   {% endfor %}


### PR DESCRIPTION
This is affecting the priority of the node groups. Instead of them being based on the `priority` field inside the node groups section, they were based on the order of the node groups.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
