### PR TITLE
Write headers before setting status code

### DIFF
--- a/cmd/async-gateway/main.go
+++ b/cmd/async-gateway/main.go
@@ -126,8 +126,8 @@ func main() {
 	router.HandleFunc(
 		"/healthz",
 		func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		},
 	)

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -209,8 +209,8 @@ func main() {
 	router := mux.NewRouter()
 	router.HandleFunc("/awaken", handler.Awaken).Methods(http.MethodPost)
 	router.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}).Methods(http.MethodGet)
 

--- a/pkg/async-gateway/endpoint.go
+++ b/pkg/async-gateway/endpoint.go
@@ -106,14 +106,14 @@ func (e *Endpoint) GetWorkload(w http.ResponseWriter, r *http.Request) {
 }
 
 func respondPlainText(w http.ResponseWriter, statusCode int, message string) {
-	w.WriteHeader(statusCode)
 	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(statusCode)
 	_, _ = w.Write([]byte(message))
 }
 
 func respondJSON(w http.ResponseWriter, statusCode int, s interface{}) error {
-	w.WriteHeader(statusCode)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
 	return json.NewEncoder(w).Encode(s)
 }
 


### PR DESCRIPTION
Writing headers after setting status code is a no-op. This is why even though we've set content-type application/json headers, the async-gateway doesn't respond with those headers.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

