### PR TITLE
Error when a nodegroup name with a dash - suffix is provided

### DIFF
--- a/pkg/lib/configreader/errors.go
+++ b/pkg/lib/configreader/errors.go
@@ -43,6 +43,7 @@ const (
 	ErrMustHavePrefix                = "configreader.must_have_prefix"
 	ErrMustHaveSuffix                = "configreader.must_have_suffix"
 	ErrCantHavePrefix                = "configreader.cant_have_prefix"
+	ErrCantHaveSuffix                = "configreader.cant_have_suffix"
 	ErrInvalidInterface              = "configreader.invalid_interface"
 	ErrInvalidFloat64                = "configreader.invalid_float64"
 	ErrInvalidFloat32                = "configreader.invalid_float32"
@@ -196,6 +197,13 @@ func ErrorCantHavePrefix(provided string, prefix string) error {
 	return errors.WithStack(&errors.Error{
 		Kind:    ErrCantHavePrefix,
 		Message: fmt.Sprintf("%s cannot start with %s", s.UserStr(provided), s.UserStr(prefix)),
+	})
+}
+
+func ErrorCantHaveSuffix(provided string, suffix string) error {
+	return errors.WithStack(&errors.Error{
+		Kind:    ErrCantHaveSuffix,
+		Message: fmt.Sprintf("%s cannot end with %s", s.UserStr(provided), s.UserStr(suffix)),
 	})
 }
 

--- a/pkg/lib/configreader/string.go
+++ b/pkg/lib/configreader/string.go
@@ -43,6 +43,7 @@ type StringValidation struct {
 	Prefix                               string
 	Suffix                               string
 	InvalidPrefixes                      []string
+	InvalidSuffixes                      []string
 	AllowedPrefixes                      []string
 	AllowedSuffixes                      []string
 	MaxLength                            int
@@ -278,6 +279,12 @@ func ValidateStringVal(val string, v *StringValidation) error {
 	for _, invalidPrefix := range v.InvalidPrefixes {
 		if strings.HasPrefix(val, invalidPrefix) {
 			return ErrorCantHavePrefix(val, invalidPrefix)
+		}
+	}
+
+	for _, invalidSuffix := range v.InvalidSuffixes {
+		if strings.HasSuffix(val, invalidSuffix) {
+			return ErrorCantHaveSuffix(val, invalidSuffix)
 		}
 	}
 

--- a/pkg/lib/configreader/string_ptr.go
+++ b/pkg/lib/configreader/string_ptr.go
@@ -36,6 +36,7 @@ type StringPtrValidation struct {
 	Prefix                               string
 	Suffix                               string
 	InvalidPrefixes                      []string
+	InvalidSuffixes                      []string
 	AllowedPrefixes                      []string
 	AllowedSuffixes                      []string
 	MaxLength                            int
@@ -68,6 +69,7 @@ func makeStringValValidation(v *StringPtrValidation) *StringValidation {
 		Prefix:                               v.Prefix,
 		Suffix:                               v.Suffix,
 		InvalidPrefixes:                      v.InvalidPrefixes,
+		InvalidSuffixes:                      v.InvalidSuffixes,
 		AllowedPrefixes:                      v.AllowedPrefixes,
 		AllowedSuffixes:                      v.AllowedSuffixes,
 		MaxLength:                            v.MaxLength,

--- a/pkg/types/clusterconfig/cluster_config.go
+++ b/pkg/types/clusterconfig/cluster_config.go
@@ -737,6 +737,7 @@ var nodeGroupsFieldValidation *cr.StructValidation = &cr.StructValidation{
 				Required:         true,
 				AlphaNumericDash: true,
 				MaxLength:        _maxNodeGroupLength,
+				InvalidSuffixes:  []string{"-"},
 			},
 		},
 		{


### PR DESCRIPTION
Nodegroup names ending with `-` spin up successfully but instances in these nodegroups never join the cluster. It also causes errors when trying to deleting a nodegroup with a `-` suffix.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

