### PR TITLE
Add cluster health docs

### DIFF
--- a/dev/generate_cli_md.sh
+++ b/dev/generate_cli_md.sh
@@ -41,6 +41,7 @@ commands=(
   "cluster configure"
   "cluster down"
   "cluster export"
+  "cluster health"
   "env configure"
   "env list"
   "env default"

--- a/docs/clients/cli.md
+++ b/docs/clients/cli.md
@@ -157,6 +157,22 @@ Flags:
   -h, --help            help for export
 ```
 
+## cluster health
+
+```text
+inspect the health of components in the cluster
+
+Usage:
+  cortex cluster health [flags]
+
+Flags:
+  -c, --config string   path to a cluster configuration file
+  -n, --name string     name of the cluster
+  -r, --region string   aws region of the cluster
+  -o, --output string   output format: one of pretty|json (default "pretty")
+  -h, --help            help for health
+```
+
 ## env configure
 
 ```text


### PR DESCRIPTION
Missed it in the last PR

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

