### PR TITLE
Load balancer doesn't obtain the endpoint when too many nodes are added on cluster-up

### DIFF
--- a/manager/manifests/istio.yaml.j2
+++ b/manager/manifests/istio.yaml.j2
@@ -55,9 +55,6 @@ spec:
               app: operator-istio-gateway
               istio: ingressgateway-operator
             ports:
-              - name: status-port  # should be first in the list, see https://github.com/istio/istio/issues/12503
-                port: 15021
-                targetPort: 15021
               - name: http2
                 port: 80
                 targetPort: 80
@@ -111,9 +108,6 @@ spec:
               app: apis-istio-gateway
               istio: ingressgateway-apis
             ports:
-              - name: status-port  # should be first in the list, see https://github.com/istio/istio/issues/12503
-                port: 15021
-                targetPort: 15021
               - name: http2
                 port: 80
                 targetPort: 80

--- a/manager/manifests/istio.yaml.j2
+++ b/manager/manifests/istio.yaml.j2
@@ -64,9 +64,6 @@ spec:
               - name: https
                 port: 443
                 targetPort: 443
-              - name: tls  # used for SNI
-                port: 15443
-                targetPort: 15443
           resources:
             requests:
               cpu: 100m
@@ -123,9 +120,6 @@ spec:
               - name: https
                 port: 443
                 targetPort: 443
-              - name: tls  # used for SNI
-                port: 15443
-                targetPort: 15443
           resources:
             requests:
               cpu: 400m

--- a/pkg/types/clusterconfig/cluster_config.go
+++ b/pkg/types/clusterconfig/cluster_config.go
@@ -50,13 +50,13 @@ const (
 	MaxNodeGroups = 100
 
 	// MaxNodesToAddOnClusterUp represents the max number of nodes to add on cluster up
-	// Limited to 150 nodes (rounded down from 164 nodes) for two reasons:
+	// Limited to 200 nodes (rounded down from 248 nodes) for two reasons:
 	//
 	// * To prevent overloading the API servers when the nodes are being added.
 	//
 	// * To prevent hitting the 500 targets per LB (when the cross-load balancing is enabled) limit (quota code L-B211E961);
-	//   500 divided by 3 target listeners - 1 operator node - 1 prometheus node => 164
-	MaxNodesToAddOnClusterUp = 150
+	//   500 divided by 2 target listeners - 1 operator node - 1 prometheus node => 248
+	MaxNodesToAddOnClusterUp = 200
 
 	// MaxNodesToAddOnClusterConfigure represents the max number of nodes to add on cluster up/configure
 	MaxNodesToAddOnClusterConfigure = 100

--- a/pkg/types/clusterconfig/cluster_config.go
+++ b/pkg/types/clusterconfig/cluster_config.go
@@ -48,8 +48,16 @@ import (
 const (
 	// MaxNodeGroups represents the max number of node groups in a cluster
 	MaxNodeGroups = 100
+
 	// MaxNodesToAddOnClusterUp represents the max number of nodes to add on cluster up
-	MaxNodesToAddOnClusterUp = 250
+	// Limited to 150 nodes (rounded down from 164 nodes) for two reasons:
+	//
+	// * To prevent overloading the API servers when the nodes are being added.
+	//
+	// * To prevent hitting the 500 targets per LB (when the cross-load balancing is enabled) limit (quota code L-B211E961);
+	//   500 divided by 3 target listeners - 1 operator node - 1 prometheus node => 164
+	MaxNodesToAddOnClusterUp = 150
+
 	// MaxNodesToAddOnClusterConfigure represents the max number of nodes to add on cluster up/configure
 	MaxNodesToAddOnClusterConfigure = 100
 	// ClusterNameTag is the tag used for storing a cluster's name in AWS resources


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
