### PR TITLE
Replace invalid image URL for test batch API

### DIFF
--- a/test/apis/batch/image-classifier-alexnet/sample.json
+++ b/test/apis/batch/image-classifier-alexnet/sample.json
@@ -1,6 +1,6 @@
 [
     "https://i.imgur.com/PzXprwl.jpg",
-    "https://i.imgur.com/RCX3U3B.png",
+    "https://i.imgur.com/a5djbnv.jpeg",
     "https://i.imgur.com/jDimNTZ.jpg",
     "https://i.imgur.com/WqeovVj.jpg"
 ]

--- a/test/apis/batch/image-classifier-alexnet/sample.json
+++ b/test/apis/batch/image-classifier-alexnet/sample.json
@@ -1,6 +1,6 @@
 [
     "https://i.imgur.com/PzXprwl.jpg",
-    "https://i.imgur.com/E4cOSLw.jpg",
+    "https://i.imgur.com/RCX3U3B.png",
     "https://i.imgur.com/jDimNTZ.jpg",
     "https://i.imgur.com/WqeovVj.jpg"
 ]


### PR DESCRIPTION
The `image-classifier-alexnet` jobs are currently failing because the [https://i.imgur.com/E4cOSLw.jpg](https://i.imgur.com/E4cOSLw.jpg) is no longer a valid URL.