### PR TITLE
Make the node groups selector part of the API spec ID

### DIFF
--- a/pkg/types/spec/api.go
+++ b/pkg/types/spec/api.go
@@ -75,6 +75,7 @@ func GetAPISpec(apiConfig *userconfig.API, initialDeploymentTime int64, deployme
 	buf.WriteString(s.Obj(apiConfig.Networking))
 	buf.WriteString(s.Obj(apiConfig.Autoscaling))
 	buf.WriteString(s.Obj(apiConfig.UpdateStrategy))
+	buf.WriteString(s.Obj(apiConfig.NodeGroups))
 	specID := hash.Bytes(buf.Bytes())[:32]
 
 	apiID := fmt.Sprintf("%s-%s-%s", MonotonicallyDecreasingID(), deploymentID, specID) // should be up to 60 characters long


### PR DESCRIPTION
Without this, running a `cortex deploy <api-name>` on an existing API that has had the `node_groups` section updated won't get updated.

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
