### PR TITLE
Fix incorrect priority on the priority expander of the cluster autoscaler

### DIFF
--- a/manager/manifests/cluster-autoscaler.yaml.j2
+++ b/manager/manifests/cluster-autoscaler.yaml.j2
@@ -145,7 +145,7 @@ data:
       {% endif %}
     {% endfor %}
     {% if found['priority'] %}
-    {{ 101-p }}:
+    {{ p }}:
     {% endif %}
     {% for ng in config['node_groups'] %}
       {% if ng['priority'] == p %}


### PR DESCRIPTION
Apparently, the priority expander (of the cluster autoscaler) sees higher values as having a higher priority, not a lower priority. This needs fixing on our part. As explained here: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md#configuration

> The priority should be a positive value. The highest value wins.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
