### PR TITLE
Fix scale-to-zero E2E test

### DIFF
--- a/test/e2e/e2e/tests.py
+++ b/test/e2e/e2e/tests.py
@@ -476,9 +476,7 @@ def test_autoscaling(
             assert api_updated(
                 client, primary_api_name, timeout=deploy_timeout
             ), "api didn't scale up to the desired number of replicas in time"
-            current_replicas = client.get_api(primary_api_name)["status"]["replica_counts"][
-                "requested"
-            ]
+            current_replicas = client.get_api(primary_api_name)["status"]["requested"]
 
             # stop the requests from being made
             if current_replicas == max_replicas and not request_stopper.is_set():

--- a/test/e2e/e2e/tests.py
+++ b/test/e2e/e2e/tests.py
@@ -908,7 +908,7 @@ def test_realtime_scale_to_zero(
 
     try:
         assert apis_ready(
-            client=client, api_names=[api_name], timeout=timeout, greater_or_equal_than=0
+            client=client, api_names=[api_name], timeout=timeout, greater_or_equal_to=0
         ), f"apis {api_name} not ready"
 
         api_info = client.get_api(api_name)

--- a/test/e2e/e2e/tests.py
+++ b/test/e2e/e2e/tests.py
@@ -908,7 +908,7 @@ def test_realtime_scale_to_zero(
 
     try:
         assert apis_ready(
-            client=client, api_names=[api_name], timeout=timeout
+            client=client, api_names=[api_name], timeout=timeout, greater_or_equal_than=0
         ), f"apis {api_name} not ready"
 
         api_info = client.get_api(api_name)

--- a/test/e2e/e2e/utils.py
+++ b/test/e2e/e2e/utils.py
@@ -39,7 +39,10 @@ def wait_for(fn: Callable[[], bool], timeout=None) -> bool:
 
 def apis_ready(client: cx.Client, api_names: List[str], timeout: Optional[int] = None) -> bool:
     def _check_liveness(status):
-        return status["requested"] == status["ready"] == status["up_to_date"]
+        return (
+            status["requested"] > 0
+            and status["requested"] == status["ready"] == status["up_to_date"]
+        )
 
     def _is_ready():
         return all([_check_liveness(client.get_api(name)["status"]) for name in api_names])

--- a/test/e2e/e2e/utils.py
+++ b/test/e2e/e2e/utils.py
@@ -41,11 +41,11 @@ def apis_ready(
     client: cx.Client,
     api_names: List[str],
     timeout: Optional[int] = None,
-    greater_or_equal_than: int = 1,
+    greater_or_equal_to: int = 1,
 ) -> bool:
     def _check_liveness(status):
         return (
-            status["requested"] >= greater_or_equal_than
+            status["requested"] >= greater_or_equal_to
             and status["requested"] == status["ready"] == status["up_to_date"]
         )
 

--- a/test/e2e/e2e/utils.py
+++ b/test/e2e/e2e/utils.py
@@ -37,10 +37,15 @@ def wait_for(fn: Callable[[], bool], timeout=None) -> bool:
         time.sleep(1)
 
 
-def apis_ready(client: cx.Client, api_names: List[str], timeout: Optional[int] = None) -> bool:
+def apis_ready(
+    client: cx.Client,
+    api_names: List[str],
+    timeout: Optional[int] = None,
+    greater_or_equal_than: int = 1,
+) -> bool:
     def _check_liveness(status):
         return (
-            status["requested"] > 0
+            status["requested"] >= greater_or_equal_than
             and status["requested"] == status["ready"] == status["up_to_date"]
         )
 


### PR DESCRIPTION
Fix scale-to-zero E2E test.

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)

