### PR TITLE
Ensure that batch containers' kubexit death dependencies environment variable is deterministic

### DIFF
--- a/pkg/workloads/k8s.go
+++ b/pkg/workloads/k8s.go
@@ -266,7 +266,7 @@ func TaskContainers(api spec.API, job *spec.JobKey) ([]kcore.Container, []kcore.
 
 		containerDeathDependencies := containerNames.Copy()
 		containerDeathDependencies.Remove(c.Name)
-		containerDeathEnvVars := getKubexitEnvVars(c.Name, containerDeathDependencies.Slice(), nil)
+		containerDeathEnvVars := getKubexitEnvVars(c.Name, containerDeathDependencies.SliceSorted(), nil)
 		containers[i].Env = append(containers[i].Env, containerDeathEnvVars...)
 
 		if c.Command[0] != "/cortex/kubexit" {
@@ -303,7 +303,7 @@ func BatchContainers(api spec.API, job *spec.BatchJob) ([]kcore.Container, []kco
 
 		containerDeathDependencies := containerNames.Copy()
 		containerDeathDependencies.Remove(c.Name)
-		containerDeathEnvVars := getKubexitEnvVars(c.Name, containerDeathDependencies.Slice(), nil)
+		containerDeathEnvVars := getKubexitEnvVars(c.Name, containerDeathDependencies.SliceSorted(), nil)
 		containers[i].Env = append(containers[i].Env, containerDeathEnvVars...)
 
 		if c.Command[0] != "/cortex/kubexit" {


### PR DESCRIPTION
checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)