### PR TITLE
fix: ./cortex/dev/export_images.sh: line 35: build/images.sh: No such…

### DIFF
--- a/dev/export_images.sh
+++ b/dev/export_images.sh
@@ -32,7 +32,7 @@ destination_ecr_prefix="cortexlabs"
 destination_registry="${aws_account_id}.dkr.ecr.${ecr_region}.amazonaws.com/${destination_ecr_prefix}"
 aws ecr get-login-password --region $ecr_region | docker login --username AWS --password-stdin $destination_registry
 
-source build/images.sh
+source $ROOT/build/images.sh
 
 # create the image repositories
 for image in "${all_images[@]}"; do


### PR DESCRIPTION
closes #2421

adding `$ROOT` when sourcing script seems to resolve the issue :)

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ ] update examples
- [ ] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex-labs.gitbook.io/staging/-MOmCGMADSRNQahK3Kox/) after merging)
- [ ] cherry-pick into release branches if applicable
- [ ] alert the dev team if the dev environment changed
