### PR TITLE
Fix cortex get pretty output for async apis

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -426,7 +426,7 @@ func getAPIsByEnv(env cliconfig.Environment) (string, error) {
 
 	if len(allAsyncAPIs) > 0 {
 		envNames := []string{}
-		for range allRealtimeAPIs {
+		for range allAsyncAPIs {
 			envNames = append(envNames, env.Name)
 		}
 


### PR DESCRIPTION
This should fix the following error seen when running `cortex get` for a cluster with more async APIs than realtime.

```
panic: runtime error: index out of range [1] with length 1 [recovered]
    panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/cortexlabs/cortex/pkg/lib/exit.Panic({0x3adf9a0, 0xc0006a6230}, {0x0, 0x0, 0x0})
    /home/circleci/project/pkg/lib/exit/exit.go:60 +0x108
github.com/cortexlabs/cortex/pkg/lib/exit.RecoverAndExit({0x0, 0x0, 0x0})
    /home/circleci/project/pkg/lib/exit/exit.go:66 +0x55
panic({0x33c3a80, 0xc00059c408})
    /usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/cortexlabs/cortex/cli/cmd.asyncAPIsTable({0xc0005b4800, 0x7, 0x3}, {0xc000341410, 0x1, 0xc00053f980})
    /home/circleci/project/cli/cmd/lib_async_apis.go:93 +0x54e
github.com/cortexlabs/cortex/cli/cmd.getAPIsByEnv({{0xc0002bd8b0, 0xd}, {0xc00053f080, 0xc0005391d0}})
    /home/circleci/project/cli/cmd/get.go:433 +0x86b
github.com/cortexlabs/cortex/cli/cmd.glob..func16.1()
    /home/circleci/project/cli/cmd/get.go:163 +0x426
github.com/cortexlabs/cortex/cli/cmd.rerun(0x2b, 0x7)
    /home/circleci/project/cli/cmd/lib_watch.go:106 +0x62
github.com/cortexlabs/cortex/cli/cmd.glob..func16(0x51ae4e0, {0xc0002d0260, 0x0, 0x2})
    /home/circleci/project/cli/cmd/get.go:92 +0x34c
github.com/spf13/cobra.(*Command).execute(0x51ae4e0, {0xc0002d0240, 0x2, 0x2})
    /home/circleci/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0x51af160)
    /home/circleci/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
    /home/circleci/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/cortexlabs/cortex/cli/cmd.Execute()
    /home/circleci/project/cli/cmd/root.go:171 +0x256
main.main()
    /home/circleci/project/cli/main.go:24 +0x17
exit status 2
```

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ ] update examples
- [ ] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex-labs.gitbook.io/staging/-MOmCGMADSRNQahK3Kox/) after merging)
- [ ] cherry-pick into release branches if applicable
- [ ] alert the dev team if the dev environment changed
