### PR TITLE
Fix: cortex get "no apis deployed" when only async apis

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -374,7 +374,7 @@ func getAPIsByEnv(env cliconfig.Environment) (string, error) {
 		}
 	}
 
-	if len(allRealtimeAPIs) == 0 && len(allBatchAPIs) == 0 && len(allTaskAPIs) == 0 && len(allTrafficSplitters) == 0 {
+	if len(allRealtimeAPIs) == 0 && len(allAsyncAPIs) == 0 && len(allBatchAPIs) == 0 && len(allTaskAPIs) == 0 && len(allTrafficSplitters) == 0 {
 		return console.Bold("no apis are deployed"), nil
 	}
 


### PR DESCRIPTION
`cortex get` shows the message "no apis are deployed" when only async apis are deployed. This is because async apis are missing from the check for any apis.

---

checklist:

- [ ] run `make test` and `make lint`
- [ ] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
- [ ] update examples
- [ ] update docs and add any new files to `summary.md` (view in [gitbook](https://cortex-labs.gitbook.io/staging/-MOmCGMADSRNQahK3Kox/) after merging)
- [ ] cherry-pick into release branches if applicable
- [ ] alert the dev team if the dev environment changed
