### PR TITLE
Send all VPC CNI logs to /dev/null by default

### DIFF
--- a/python/client/cortex/binary/__init__.py
+++ b/python/client/cortex/binary/__init__.py
@@ -25,7 +25,10 @@ def run():
     Runs the CLI from terminal.
     """
     try:
-        process = subprocess.run([get_cli_path()] + sys.argv[1:], cwd=os.getcwd())
+        env = os.environ.copy()
+        if "AWS_VPC_K8S_CNI_LOG_FILE" not in env:
+            env["AWS_VPC_K8S_CNI_LOG_FILE"] = "/dev/null"
+        process = subprocess.run([get_cli_path()] + sys.argv[1:], cwd=os.getcwd(), env=env)
     except KeyboardInterrupt:
         sys.exit(130)  # Ctrl + C
     sys.exit(process.returncode)
@@ -51,6 +54,8 @@ def run_cli(
 
     env = os.environ.copy()
     env["CORTEX_CLI_INVOKER"] = "python"
+    if "AWS_VPC_K8S_CNI_LOG_FILE" not in env:
+        env["AWS_VPC_K8S_CNI_LOG_FILE"] = "/dev/null"
     process = subprocess.Popen(
         [get_cli_path()] + args,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
Without this PR, the following lines would constantly get printed on screen when the `cortex` CLI is run:

```
2022-09-09 16:59:13.481063827 +0000 UTC m=+0.039526031 write error: can't make directories for new logfile: mkdir /host: permission denied
2022-09-09 16:59:13.481448123 +0000 UTC m=+0.039910297 write error: can't make directories for new logfile: mkdir /host: permission denied
```

---

checklist:

- [x] run `make test` and `make lint`
- [x] test manually (i.e. build/push all images, restart operator, and re-deploy APIs)
